### PR TITLE
SetDirty() only called on settings if GUI registers change.

### DIFF
--- a/Assets/Plugins/Editor/FMOD/SettingsEditor.cs
+++ b/Assets/Plugins/Editor/FMOD/SettingsEditor.cs
@@ -304,7 +304,7 @@ namespace FMODUnity
         {
             Settings settings = target as Settings;
             
-            EditorUtility.SetDirty(settings);
+            EditorGUI.BeginChangeCheck();
 
             hasBankSourceChanged = false;
 
@@ -429,6 +429,10 @@ namespace FMODUnity
             if (!validBanks)
             {
                 EditorGUILayout.HelpBox(failReason, MessageType.Error, true);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    EditorUtility.SetDirty(settings);
+                }
                 return;
             }
 
@@ -520,6 +524,11 @@ namespace FMODUnity
             DisplayPlatform(FMODPlatform.Desktop, null);
 			DisplayPlatform(FMODPlatform.Mobile, new FMODPlatform[] { FMODPlatform.MobileHigh, FMODPlatform.MobileLow, FMODPlatform.PSVita, FMODPlatform.AppleTV });
             DisplayPlatform(FMODPlatform.Console, new FMODPlatform[] { FMODPlatform.XboxOne, FMODPlatform.PS4, FMODPlatform.WiiU });
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorUtility.SetDirty(settings);
+            }
 
             if (hasBankSourceChanged)
             {


### PR DESCRIPTION
Defers dirtying and thus re-serialising the Settings object until the Inspector GUI has registered a changed field.