### PR TITLE
Added ObjectEnable and ObjectDisable to EmitterGameEvent

### DIFF
--- a/Assets/Plugins/FMOD/RuntimeUtils.cs
+++ b/Assets/Plugins/FMOD/RuntimeUtils.cs
@@ -89,6 +89,8 @@ namespace FMODUnity
         TriggerExit,
         CollisionEnter,
         CollisionExit,
+		ObjectEnable,
+		ObjectDisable
     }
 
     public enum LoaderGameEvent

--- a/Assets/Plugins/FMOD/StudioEventEmitter.cs
+++ b/Assets/Plugins/FMOD/StudioEventEmitter.cs
@@ -66,6 +66,16 @@ namespace FMODUnity
                 }
             }
         }
+		
+		void OnEnable()
+		{
+			HandleGameEvent(EmitterGameEvent.ObjectEnable);
+		}
+		
+		void OnDisable()
+		{
+			HandleGameEvent(EmitterGameEvent.ObjectDisable);
+		}
 
         void OnTriggerEnter(Collider other)
         {

--- a/Assets/Plugins/FMOD/StudioParameterTrigger.cs
+++ b/Assets/Plugins/FMOD/StudioParameterTrigger.cs
@@ -62,16 +62,6 @@ namespace FMODUnity
         {
             HandleGameEvent(EmitterGameEvent.CollisionExit);
         }
-		
-		void OnEnable()
-		{
-			HandleGameEvent(EmitterGameEvent.ObjectEnable);
-		}
-		
-		void OnDisable()
-		{
-			HandleGameEvent(EmitterGameEvent.ObjectDisable);
-		}
 
         void HandleGameEvent(EmitterGameEvent gameEvent)
         {

--- a/Assets/Plugins/FMOD/StudioParameterTrigger.cs
+++ b/Assets/Plugins/FMOD/StudioParameterTrigger.cs
@@ -26,6 +26,16 @@ namespace FMODUnity
         {
             HandleGameEvent(EmitterGameEvent.ObjectDestroy);
         }
+		
+		void OnEnable()
+		{
+			HandleGameEvent(EmitterGameEvent.ObjectEnable);
+		}
+		
+		void OnDisable()
+		{
+			HandleGameEvent(EmitterGameEvent.ObjectDisable);
+		}
 
         void OnTriggerEnter(Collider other)
         {
@@ -52,6 +62,16 @@ namespace FMODUnity
         {
             HandleGameEvent(EmitterGameEvent.CollisionExit);
         }
+		
+		void OnEnable()
+		{
+			HandleGameEvent(EmitterGameEvent.ObjectEnable);
+		}
+		
+		void OnDisable()
+		{
+			HandleGameEvent(EmitterGameEvent.ObjectDisable);
+		}
 
         void HandleGameEvent(EmitterGameEvent gameEvent)
         {


### PR DESCRIPTION
Enables playing/stopping different events or changing parameters through animations by adding multiple emitters as childs and enabling/disabling them while the animation is running. It is much more flexible than animation events calling Play().