### PR TITLE
Fixed error not included in interpolated string.

### DIFF
--- a/Assets/Plugins/FMOD/RuntimeUtils.cs
+++ b/Assets/Plugins/FMOD/RuntimeUtils.cs
@@ -55,7 +55,7 @@ namespace FMODUnity
             Result = result;
         }
         public BankLoadException(string path, string error)
-            : base(String.Format("FMOD Studio could not load bank '{0}' : ", path, error))
+            : base(String.Format("FMOD Studio could not load bank '{0}' : {1}", path, error))
         {
             Path = path;
             Result = FMOD.RESULT.ERR_INTERNAL;


### PR DESCRIPTION
The `{1}` to include the error was missing. (Longstanding niggle.)