### PR TITLE
Fix for Mac editor attempting to load plugins from the Linux folder when build platform is set to Linux.

### DIFF
--- a/Assets/Plugins/FMOD/RuntimeUtils.cs
+++ b/Assets/Plugins/FMOD/RuntimeUtils.cs
@@ -362,10 +362,10 @@ namespace FMODUnity
 	                string pluginFolder = Application.dataPath + "/Plugins/X86_64/";
 	            #elif UNITY_EDITOR_WIN
 	                string pluginFolder = Application.dataPath + "/Plugins/X86/";
-                #elif UNITY_STANDALONE_LINUX
-                    string pluginFolder = Application.dataPath + ((IntPtr.Size == 8) ? "/Plugins/x86_64/" : "/Plugins/x86/");
 	            #elif UNITY_STANDALONE_WIN || UNITY_PS4 || UNITY_XBOXONE || UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX || UNITY_WSA_10_0
 	                string pluginFolder = Application.dataPath + "/Plugins/";
+		    #elif UNITY_STANDALONE_LINUX
+                        string pluginFolder = Application.dataPath + ((IntPtr.Size == 8) ? "/Plugins/x86_64/" : "/Plugins/x86/");
 	            #elif UNITY_WINRT_8_1
 	                string pluginFolder = "";
 	            #elif UNITY_ANDROID            


### PR DESCRIPTION
As I understand it, all `UNITY_EDITOR_*` directives should come first, otherwise the build platform overrides the editor platform even in editor.