### PR TITLE
Allow StringHelper byteFromStringUTF8 to return null

### DIFF
--- a/Assets/Plugins/FMOD/Wrapper/fmod.cs
+++ b/Assets/Plugins/FMOD/Wrapper/fmod.cs
@@ -4457,6 +4457,9 @@ namespace FMOD
 
             public byte[] byteFromStringUTF8(string s)
             {
+                if (s == null)
+                    return null;
+                
                 // Allow one extra byte for null terminator
                 int maximumLength = encoding.GetMaxByteCount(s.Length) + 1;
                 if (maximumLength > buffer.Length)


### PR DESCRIPTION
Allow StringHelper byteFromStringUTF8 to return null for native calls that accepts it, such as Sound::getTag