### PR TITLE
Use 2018.2 menu item path for inspector.

### DIFF
--- a/Assets/Plugins/FMOD/Settings.cs
+++ b/Assets/Plugins/FMOD/Settings.cs
@@ -117,7 +117,11 @@ namespace FMODUnity
         public static void EditSettings()
         {
             Selection.activeObject = Instance;
+            #if UNITY_2018_2_OR_NEWER
+            EditorApplication.ExecuteMenuItem("Window/General/Inspector");
+            #else
             EditorApplication.ExecuteMenuItem("Window/Inspector");
+            #endif
         }
         #endif
 


### PR DESCRIPTION
Fixes an error in Unity 2018.2 when using FMOD > Edit Settings that prevented the inspector window from be displayed.