### PR TITLE
Fixed AttachInstanceToGameObject positioning not being applied correctly and eliminate the DebugOverlay Garbage Collection overhead

### DIFF
--- a/Assets/Plugins/FMOD/FMODRuntimeManagerOnGUIHelper.cs
+++ b/Assets/Plugins/FMOD/FMODRuntimeManagerOnGUIHelper.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FMODUnity
+{
+	public class FMODRuntimeManagerOnGUIHelper : MonoBehaviour
+	{
+		public RuntimeManager TargetRuntimeManager = null;
+
+		private void OnGUI()
+		{
+			if (TargetRuntimeManager) TargetRuntimeManager.ExecuteOnGUI();
+		}
+	}
+}

--- a/Assets/Plugins/FMOD/RuntimeManager.cs
+++ b/Assets/Plugins/FMOD/RuntimeManager.cs
@@ -384,6 +384,7 @@ retry:
             attachedInstance.transform = transform;
             attachedInstance.instance = instance;
             attachedInstance.rigidBody = rigidBody;
+            instance.set3DAttributes(FMODUnity.RuntimeUtils.To3DAttributes(transform, rigidBody));
             Instance.attachedInstances.Add(attachedInstance);
         }
 
@@ -394,6 +395,7 @@ retry:
             attachedInstance.instance = instance;
             attachedInstance.rigidBody2D = rigidBody2D;
             attachedInstance.rigidBody = null;
+            instance.set3DAttributes(FMODUnity.RuntimeUtils.To3DAttributes(transform, rigidBody2D));
             Instance.attachedInstances.Add(attachedInstance);
         }
 


### PR DESCRIPTION
Fixed issues with the AttachInstanceToGameObject methods.
This mainly fixes issues when being called via the PlayOneShotAttached method.
AttachInstanceToGameObject  now directly sets the 3dAttribute while attaching to ensure an initial correct and valid 3d positioning is applied.
Before a 3d position would only by applied to the instance in the next update after the attach occured.
This can cause unexpected and unwanted results in case the target transform was destroyed between the attach and the update loop.

Example: A crate that plays a PlayOneShotAttached when it hits a surface but that also takes damage at the same time that can result in a destroy. The sound would play at the incorrect location as there was never an initial position set that matched the desired start position. This small change will fix this.

Also added a small change to the way the DebugOverlay is being activated and rendered removing a Garbage Collection overhead in both editor and standalone builds, even if the overlay was not enabled.
Before, even just having an OnGUI method in your component would trigger the Unity legacy UI system to be running causing a performance overhead, even if nothing is being drawn as well as an occasional garbage allocation. This is now only the case if the debug overlay is enabled, removing all the overhead that was being created when the debug overlay is disabled.