### PR TITLE
A event driven way of managing the destroying of the editor systems

### DIFF
--- a/Assets/Plugins/Editor/FMOD/EditorUtils.cs
+++ b/Assets/Plugins/Editor/FMOD/EditorUtils.cs
@@ -174,6 +174,7 @@ namespace FMODUnity
         {
             EditorApplication.update += Update;
             #if UNITY_2017_2_OR_NEWER
+            AssemblyReloadEvents.beforeAssemblyReload += HandleBeforeAssemblyReload;
             EditorApplication.playModeStateChanged += HandleOnPlayModeChanged;
             EditorApplication.pauseStateChanged += HandleOnPausedModeChanged;
             #else
@@ -182,6 +183,13 @@ namespace FMODUnity
         }
 
         #if UNITY_2017_2_OR_NEWER
+        static void HandleBeforeAssemblyReload()
+        {
+            // Reloading assemblies causes losing of all state
+            // This is the last chance to clean up FMOD and avoid a leak.
+            DestroySystem();
+        }
+        
         static void HandleOnPausedModeChanged(PauseState state)
         {
             if (RuntimeManager.IsInitialized && RuntimeManager.HasBanksLoaded)
@@ -224,6 +232,7 @@ namespace FMODUnity
 
         static void Update()
         {
+            #if !UNITY_2017_2_OR_NEWER
             // Compilation will cause scripts to reload, losing all state
             // This is the last chance to clean up FMOD and avoid a leak.
             if (EditorApplication.isCompiling)
@@ -231,6 +240,7 @@ namespace FMODUnity
                 DestroySystem();
                 RuntimeManager.Destroy();
             }
+            #endif
 
             // Update the editor system
             if (system.isValid())


### PR DESCRIPTION
This avoids the issue of printing unnecessary error messages when the using custom logic on when the assemblies are being reloaded. e.g. [this gist](https://gist.github.com/eetuvartia/59052fd4b5b7efbe068285013b64d042) prevents reloading the assemblies when EditorApplication is playing. With these changes the editor systems are being destroyed just before the assemblies are being reloaded.