### PR TITLE
Debug overlay window ID is too common

### DIFF
--- a/Assets/Plugins/FMOD/src/Runtime/RuntimeManager.cs
+++ b/Assets/Plugins/FMOD/src/Runtime/RuntimeManager.cs
@@ -470,7 +470,8 @@ retry:
         {
             if (studioSystem.isValid() && isOverlayEnabled)
             {
-                windowRect = GUI.Window(0, windowRect, DrawDebugOverlay, "FMOD Studio Debug");
+                int window_id = ('F'+'M'+'O'+'D' + 'D'+'E'+'B'+'U'+'G' + 'O'+'V'+'E'+'R'+'L'+'A'+'Y') * 0xC001 ;
+                windowRect = GUI.Window(window_id, windowRect, DrawDebugOverlay, "FMOD Studio Debug");
             }
         }
 


### PR DESCRIPTION
Debug overlay window ID is too common and may easily conflict with people's code, making the debug overlay disappear and/or creating erratic behavior on the GUI code of the games. 

Giving 0 for the window ID is probably what 6502% of people do when writing some GUI code and the Internet is littered with examples using this value. Changing it to an unlikely value vastly reduces the possibility for errors. 

This affects both FMOD 1.x and 2.x versions and the fix is exactly the same.

It could maybe be a good idea to document this on the FMOD documentation too, just in case.