### PR TITLE
fix sound stopping in editor when focus is lost

### DIFF
--- a/Assets/Plugins/FMOD/src/Runtime/RuntimeManager.cs
+++ b/Assets/Plugins/FMOD/src/Runtime/RuntimeManager.cs
@@ -586,7 +586,7 @@ retry:
         }
         #endif
 
-        #if UNITY_IOS
+        #if UNITY_IOS && !UNITY_EDITOR
         /* iOS alarm interruptions do not trigger OnApplicationPause
          * Sending the app to the background does trigger OnApplicationFocus
          * We don't want to use this on Android as other things (like the keyboard)


### PR DESCRIPTION
maybe I'm missing something? but this is the only way I could manage to work on a mobile projet, without the sound stopping when the game window focus is lost