### PR TITLE
Remove obsolete case to avoid build error

### DIFF
--- a/Assets/Plugins/FMOD/src/Runtime/RuntimeUtils.cs
+++ b/Assets/Plugins/FMOD/src/Runtime/RuntimeUtils.cs
@@ -421,7 +421,9 @@ namespace FMODUnity
                 #if !UNITY_2019_2_OR_NEWER
                 case BuildTarget.StandaloneLinux:
                 #endif
+                #if !UNITY_2019_3_OR_NEWER
                 case BuildTarget.StandaloneLinuxUniversal:
+                #endif
                 case BuildTarget.StandaloneLinux64:
                     return FMODPlatform.Linux;
                 case BuildTarget.StandaloneOSX:


### PR DESCRIPTION
StandaloneLinuxUniversal was made obsolete in 2019.3
https://docs.unity3d.com/ScriptReference/BuildTarget.StandaloneLinuxUniversal.html