### PR TITLE
Start events with correct offset in Unity Timeline 

### DIFF
--- a/Assets/Plugins/FMOD/src/FMODEventPlayable.cs
+++ b/Assets/Plugins/FMOD/src/FMODEventPlayable.cs
@@ -156,7 +156,7 @@ namespace FMODUnity
         private FMOD.Studio.EventInstance eventInstance;
         private float currentVolume = 1;
 
-        protected void PlayEvent()
+        protected void PlayEvent(int timelinePosition = 0)
         {
             if (!eventReference.IsNull)
             {
@@ -193,16 +193,17 @@ namespace FMODUnity
                     eventInstance.setParameterByID(param.ID, param.Value);
                 }
 
+                eventInstance.setTimelinePosition(timelinePosition);
                 eventInstance.setVolume(currentVolume);
                 eventInstance.start();
             }
         }
 
-        public void OnEnter()
+        public void OnEnter(double time)
         {
             if (!isPlayheadInside)
             {
-                PlayEvent();
+                PlayEvent((int)(time * 1000));
                 isPlayheadInside = true;
             }
         }
@@ -249,7 +250,7 @@ namespace FMODUnity
 
             if ((time >= OwningClip.start) && (time < OwningClip.end))
             {
-                OnEnter();
+                OnEnter(time - OwningClip.start);
             }
             else
             {


### PR DESCRIPTION
This adds support for starting FMOD sounds in a Unity Timeline with the correct offset when the playhead is in the middle of a clip.
 
Currently the event is always started from the beginning. This is a problem for example if you pause the Timeline and then resume it while in the middle of an FMOD clip. The event will be restarted anew and won't be synchronized anymore.
Also with this change, in the editor you will be able to press play with the playhead in the middle of an FMOD clip and it will start halfway through.