### PR TITLE
Tiny QoL update:suppress CS0649 on Unity reference

### DIFF
--- a/Assets/Plugins/FMOD/src/StudioListener.cs
+++ b/Assets/Plugins/FMOD/src/StudioListener.cs
@@ -7,7 +7,7 @@ namespace FMODUnity
     public class StudioListener : MonoBehaviour
     {
         [SerializeField]
-        private GameObject attenuationObject;
+        private GameObject attenuationObject = null;
 
 #if UNITY_PHYSICS_EXIST
         private Rigidbody rigidBody;


### PR DESCRIPTION
Unity 2019.4.0:
This will suppress CS0649: Field 'StudioListener.attenuationObject' is never assigned to, and will always have its default value null
- will otherwise prevent successful compilation when project is compiled w/ -warnaserror ('warnings as errors')