### PR TITLE
Fix wrong names, change "Event" to "AudioEvent" to be less confuse

### DIFF
--- a/Assets/Plugins/FMOD/Cache.meta
+++ b/Assets/Plugins/FMOD/Cache.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df862051d24b5ed4f8106df7c10c8a8e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/FMOD/Cache/Editor.meta
+++ b/Assets/Plugins/FMOD/Cache/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ec0e6bfb691d974dbad43a44634b172
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d32cf7c32a3ed8347bac48ef5ed56d82, type: 3}
+  m_Name: FMODStudioCache
+  m_EditorClassIdentifier: 
+  EditorBanks: []
+  EditorEvents: []
+  EditorParameters: []
+  MasterBanks: []
+  StringsBanks: []
+  cacheTime: 0
+  cacheVersion: 131621

--- a/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset.meta
+++ b/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94d80da73e1a3c8428eeb98c04005af7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/FMOD/Resources.meta
+++ b/Assets/Plugins/FMOD/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b75b49a49b72b58438b0919417b6f3e4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset
+++ b/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset
@@ -1,0 +1,69 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eef8d824ea7b63742966aaa0e94ac383, type: 3}
+  m_Name: FMODStudioSettings
+  m_EditorClassIdentifier: 
+  switchSettingsMigration: 1
+  HasSourceProject: 1
+  HasPlatforms: 1
+  sourceProjectPath: 
+  sourceBankPath: 
+  sourceBankPathUnformatted: 
+  BankRefreshCooldown: 5
+  ShowBankRefreshWindow: 1
+  AutomaticEventLoading: 1
+  BankLoadType: 0
+  AutomaticSampleLoading: 0
+  EncryptionKey: 
+  ImportType: 0
+  TargetAssetPath: FMODBanks
+  TargetBankFolder: 
+  EventLinkage: 0
+  LoggingLevel: 2
+  SpeakerModeSettings: []
+  SampleRateSettings: []
+  LiveUpdateSettings: []
+  OverlaySettings: []
+  BankDirectorySettings: []
+  VirtualChannelSettings: []
+  RealChannelSettings: []
+  Plugins: []
+  MasterBanks: []
+  Banks: []
+  BanksToLoad: []
+  LiveUpdatePort: 9264
+  EnableMemoryTracking: 0
+  AndroidUseOBB: 0
+  AndroidPatchBuild: 0
+  MeterChannelOrdering: 0
+  StopEventsOutsideMaxDistance: 0
+  BoltUnitOptionsBuildPending: 0
+  EnableErrorCallback: 0
+  SharedLibraryUpdateStage: 0
+  SharedLibraryTimeSinceStart: 0
+  CurrentVersion: 131621
+  HideSetupWizard: 0
+  LastEventReferenceScanVersion: 131621
+  Platforms:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  MigratedPlatforms: 0500000000000000060000000a0000000800000009000000120000000c000000150000000b0000000200000001000000

--- a/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset.meta
+++ b/Assets/Plugins/FMOD/Resources/FMODStudioSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1bd2ff0679ae1e418b0f70eb8fc3112
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/FMOD/src/AudioEventRefAttribute.cs
+++ b/Assets/Plugins/FMOD/src/AudioEventRefAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using UnityEngine;
+
+namespace FMODUnity
+{
+    [Obsolete("Use the EventReference struct instead")]
+    public class AudioEventRefAttribute : PropertyAttribute
+    {
+        public string MigrateTo = null;
+    }
+}

--- a/Assets/Plugins/FMOD/src/AudioEventRefAttribute.cs.meta
+++ b/Assets/Plugins/FMOD/src/AudioEventRefAttribute.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: b11b989f1afe07e4eb1e3679b562d860
-timeCreated: 1432600216
+guid: 1b29a1189268c3b47aa2ec4b96a9e7ef
+timeCreated: 1445311748
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Plugins/FMOD/src/Editor/AudioEventBrowser.cs
+++ b/Assets/Plugins/FMOD/src/Editor/AudioEventBrowser.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
-using System.IO;
 
 namespace FMODUnity
 {
-    public class EventBrowser : EditorWindow, ISerializationCallbackReceiver
+    public class AudioEventBrowser : EditorWindow, ISerializationCallbackReceiver
     {
         [SerializeField]
         private bool isStandaloneWindow;
@@ -47,7 +45,7 @@ namespace FMODUnity
         [MenuItem("FMOD/Event Browser", priority = 2)]
         public static void ShowWindow()
         {
-            EventBrowser eventBrowser = GetWindow<EventBrowser>("FMOD Events");
+            AudioEventBrowser eventBrowser = GetWindow<AudioEventBrowser>("FMOD Events");
             eventBrowser.minSize = new Vector2(380, 600);
 
             eventBrowser.BeginStandaloneWindow();
@@ -80,7 +78,7 @@ namespace FMODUnity
                 forceRepaint = true;
             }
 
-            if (LastKnownCacheTime != EventManager.CacheTime)
+            if (LastKnownCacheTime != AudioEventManager.CacheTime)
             {
                 ReadEventCache();
                 forceRepaint = true;
@@ -95,7 +93,7 @@ namespace FMODUnity
 
         private void ReadEventCache()
         {
-            LastKnownCacheTime = EventManager.CacheTime;
+            LastKnownCacheTime = AudioEventManager.CacheTime;
             treeView.Reload();
         }
 
@@ -261,21 +259,21 @@ namespace FMODUnity
                 if ((TypeFilter & TypeFilter.Event) != 0)
                 {
                     CreateSubTree("Events", EventPrefix,
-                        EventManager.Events.Where(e => e.Path.StartsWith(EventPrefix)), e => e.Path);
+                        AudioEventManager.Events.Where(e => e.Path.StartsWith(EventPrefix)), e => e.Path);
 
                     CreateSubTree("Snapshots", SnapshotPrefix,
-                        EventManager.Events.Where(e => e.Path.StartsWith(SnapshotPrefix)), s => s.Path);
+                        AudioEventManager.Events.Where(e => e.Path.StartsWith(SnapshotPrefix)), s => s.Path);
                 }
 
                 if ((TypeFilter & TypeFilter.Bank) != 0)
                 {
-                    CreateSubTree("Banks", BankPrefix, EventManager.Banks, b => b.StudioPath);
+                    CreateSubTree("Banks", BankPrefix, AudioEventManager.Banks, b => b.StudioPath);
                 }
 
                 if ((TypeFilter & TypeFilter.Parameter) != 0)
                 {
                     CreateSubTree("Global Parameters", ParameterPrefix,
-                        EventManager.Parameters, p => p.StudioPath);
+                        AudioEventManager.Parameters, p => p.StudioPath);
                 }
 
                 List<TreeViewItem> rows = new List<TreeViewItem>();
@@ -301,7 +299,8 @@ namespace FMODUnity
 
                 if (hasSearch)
                 {
-                    records = records.Where(r => {
+                    records = records.Where(r =>
+                    {
                         foreach (var word in searchStringSplit)
                         {
                             if (word.Length > 0 && r.path.IndexOf(word, StringComparison.OrdinalIgnoreCase) < 0)
@@ -371,7 +370,7 @@ namespace FMODUnity
                 EditorParamRef paramRef = record as EditorParamRef;
                 if (paramRef != null)
                 {
-                    switch(paramRef.Type)
+                    switch (paramRef.Type)
                     {
                         case ParameterType.Continuous:
                             return continuousParameterIcon;
@@ -756,13 +755,13 @@ namespace FMODUnity
             private TransportControls transportControls = new TransportControls();
 
             [SerializeField]
-            private Event3DPreview event3DPreview = new Event3DPreview();
+            private AudioEvent3DPreview event3DPreview = new AudioEvent3DPreview();
 
             [SerializeField]
             private PreviewMeters meters = new PreviewMeters();
 
             [SerializeField]
-            private EventParameterControls parameterControls = new EventParameterControls();
+            private AudioEventParameterControls parameterControls = new AudioEventParameterControls();
 
             private GUIStyle mainStyle;
 
@@ -785,7 +784,7 @@ namespace FMODUnity
 
             private void AffirmResources()
             {
-                if (mainStyle ==  null)
+                if (mainStyle == null)
                 {
                     mainStyle = new GUIStyle(GUI.skin.box);
                     mainStyle.margin = new RectOffset();
@@ -1091,7 +1090,7 @@ namespace FMODUnity
         }
 
         [Serializable]
-        private class Event3DPreview
+        private class AudioEvent3DPreview
         {
             private bool isDragging;
             private Rect arenaRect;
@@ -1212,7 +1211,7 @@ namespace FMODUnity
         }
 
         [Serializable]
-        private class EventParameterControls
+        private class AudioEventParameterControls
         {
             [NonSerialized]
             private Dictionary<string, float> parameterValues = new Dictionary<string, float>();
@@ -1329,7 +1328,7 @@ namespace FMODUnity
 
                 float baseX = fullRect.x + (fullRect.width - (meterWidth * metering.Length)) / 2;
 
-                for(int i = 0; i < metering.Length; i++)
+                for (int i = 0; i < metering.Length; i++)
                 {
                     Rect meterRect = new Rect(baseX + meterPositions[i], fullRect.y, meterWidth, fullRect.height);
 
@@ -1357,22 +1356,22 @@ namespace FMODUnity
 
             private FMOD.SPEAKERMODE speakerModeForChannelCount(int channelCount)
             {
-                switch(channelCount)
+                switch (channelCount)
                 {
-                case 1:
-                    return FMOD.SPEAKERMODE.MONO;
-                case 4:
-                    return FMOD.SPEAKERMODE.QUAD;
-                case 5:
-                    return FMOD.SPEAKERMODE.SURROUND;
-                case 6:
-                    return FMOD.SPEAKERMODE._5POINT1;
-                case 8:
-                    return FMOD.SPEAKERMODE._7POINT1;
-                case 12:
-                    return FMOD.SPEAKERMODE._7POINT1POINT4;
-                default:
-                    return FMOD.SPEAKERMODE.STEREO;
+                    case 1:
+                        return FMOD.SPEAKERMODE.MONO;
+                    case 4:
+                        return FMOD.SPEAKERMODE.QUAD;
+                    case 5:
+                        return FMOD.SPEAKERMODE.SURROUND;
+                    case 6:
+                        return FMOD.SPEAKERMODE._5POINT1;
+                    case 8:
+                        return FMOD.SPEAKERMODE._7POINT1;
+                    case 12:
+                        return FMOD.SPEAKERMODE._7POINT1POINT4;
+                    default:
+                        return FMOD.SPEAKERMODE.STEREO;
                 }
             }
 
@@ -1380,170 +1379,170 @@ namespace FMODUnity
             {
                 List<float> offsets = new List<float>();
 
-                switch(mode)
+                switch (mode)
                 {
-                case FMOD.SPEAKERMODE.MONO: // M
-                    offsets.Add(0);
-                    break;
+                    case FMOD.SPEAKERMODE.MONO: // M
+                        offsets.Add(0);
+                        break;
 
-                case FMOD.SPEAKERMODE.STEREO: // L R
-                    offsets.Add(0);
-                    offsets.Add(meterWidth);
-                    break;
+                    case FMOD.SPEAKERMODE.STEREO: // L R
+                        offsets.Add(0);
+                        offsets.Add(meterWidth);
+                        break;
 
-                case FMOD.SPEAKERMODE.QUAD:
-                    switch(Settings.Instance.MeterChannelOrdering)
-                    {
-                    case MeterChannelOrderingType.Standard:
-                    case MeterChannelOrderingType.SeparateLFE: // L R | LS RS
-                        offsets.Add(0); // L
-                        offsets.Add(meterWidth*1); // R
-                        offsets.Add(meterWidth*2 + groupGap); // LS
-                        offsets.Add(meterWidth*3 + groupGap); // RS
+                    case FMOD.SPEAKERMODE.QUAD:
+                        switch (Settings.Instance.MeterChannelOrdering)
+                        {
+                            case MeterChannelOrderingType.Standard:
+                            case MeterChannelOrderingType.SeparateLFE: // L R | LS RS
+                                offsets.Add(0); // L
+                                offsets.Add(meterWidth * 1); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // LS
+                                offsets.Add(meterWidth * 3 + groupGap); // RS
+                                break;
+                            case MeterChannelOrderingType.Positional: // LS | L R | RS
+                                offsets.Add(meterWidth * 1 + groupGap); // L
+                                offsets.Add(meterWidth * 2 + groupGap); // R
+                                offsets.Add(0); // LS
+                                offsets.Add(meterWidth * 3 + groupGap * 2); // RS
+                                break;
+                        }
                         break;
-                    case MeterChannelOrderingType.Positional: // LS | L R | RS
-                        offsets.Add(meterWidth*1 + groupGap); // L
-                        offsets.Add(meterWidth*2 + groupGap); // R
-                        offsets.Add(0); // LS
-                        offsets.Add(meterWidth*3 + groupGap*2); // RS
-                        break;
-                    }
-                    break;
 
-                case FMOD.SPEAKERMODE.SURROUND:
-                    switch(Settings.Instance.MeterChannelOrdering)
-                    {
-                    case MeterChannelOrderingType.Standard:
-                    case MeterChannelOrderingType.SeparateLFE: // L R | C | LS RS
-                        offsets.Add(0); // L
-                        offsets.Add(meterWidth*1); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(meterWidth*3 + groupGap*2); // LS
-                        offsets.Add(meterWidth*4 + groupGap*2); // RS
+                    case FMOD.SPEAKERMODE.SURROUND:
+                        switch (Settings.Instance.MeterChannelOrdering)
+                        {
+                            case MeterChannelOrderingType.Standard:
+                            case MeterChannelOrderingType.SeparateLFE: // L R | C | LS RS
+                                offsets.Add(0); // L
+                                offsets.Add(meterWidth * 1); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(meterWidth * 3 + groupGap * 2); // LS
+                                offsets.Add(meterWidth * 4 + groupGap * 2); // RS
+                                break;
+                            case MeterChannelOrderingType.Positional: // LS | L C R | RS
+                                offsets.Add(meterWidth * 1 + groupGap); // L
+                                offsets.Add(meterWidth * 3 + groupGap); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(0); // LS
+                                offsets.Add(meterWidth * 4 + groupGap * 2); // RS
+                                break;
+                        }
                         break;
-                    case MeterChannelOrderingType.Positional: // LS | L C R | RS
-                        offsets.Add(meterWidth*1 + groupGap); // L
-                        offsets.Add(meterWidth*3 + groupGap); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(0); // LS
-                        offsets.Add(meterWidth*4 + groupGap*2); // RS
-                        break;
-                    }
-                    break;
 
-                case FMOD.SPEAKERMODE._5POINT1:
-                    switch(Settings.Instance.MeterChannelOrdering)
-                    {
-                    case MeterChannelOrderingType.Standard: // L R | C | LFE | LS RS
-                        offsets.Add(0); // L
-                        offsets.Add(meterWidth*1); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(meterWidth*3 + groupGap*2); // LFE
-                        offsets.Add(meterWidth*4 + groupGap*3); // LS
-                        offsets.Add(meterWidth*5 + groupGap*3); // RS
+                    case FMOD.SPEAKERMODE._5POINT1:
+                        switch (Settings.Instance.MeterChannelOrdering)
+                        {
+                            case MeterChannelOrderingType.Standard: // L R | C | LFE | LS RS
+                                offsets.Add(0); // L
+                                offsets.Add(meterWidth * 1); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(meterWidth * 3 + groupGap * 2); // LFE
+                                offsets.Add(meterWidth * 4 + groupGap * 3); // LS
+                                offsets.Add(meterWidth * 5 + groupGap * 3); // RS
+                                break;
+                            case MeterChannelOrderingType.SeparateLFE: // L R | C | LS RS || LFE
+                                offsets.Add(0); // L
+                                offsets.Add(meterWidth * 1); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(meterWidth * 5 + groupGap * 2 + lfeGap); // LFE
+                                offsets.Add(meterWidth * 3 + groupGap * 2); // LS
+                                offsets.Add(meterWidth * 4 + groupGap * 2); // RS
+                                break;
+                            case MeterChannelOrderingType.Positional: // LS | L C R | RS || LFE
+                                offsets.Add(meterWidth * 1 + groupGap); // L
+                                offsets.Add(meterWidth * 3 + groupGap); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(meterWidth * 5 + groupGap * 2 + lfeGap); // LFE
+                                offsets.Add(0); // LS
+                                offsets.Add(meterWidth * 4 + groupGap * 2); // RS
+                                break;
+                        }
                         break;
-                    case MeterChannelOrderingType.SeparateLFE: // L R | C | LS RS || LFE
-                        offsets.Add(0); // L
-                        offsets.Add(meterWidth*1); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(meterWidth*5 + groupGap*2 + lfeGap); // LFE
-                        offsets.Add(meterWidth*3 + groupGap*2); // LS
-                        offsets.Add(meterWidth*4 + groupGap*2); // RS
-                        break;
-                    case MeterChannelOrderingType.Positional: // LS | L C R | RS || LFE
-                        offsets.Add(meterWidth*1 + groupGap); // L
-                        offsets.Add(meterWidth*3 + groupGap); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(meterWidth*5 + groupGap*2 + lfeGap); // LFE
-                        offsets.Add(0); // LS
-                        offsets.Add(meterWidth*4 + groupGap*2); // RS
-                        break;
-                    }
-                    break;
 
-                case FMOD.SPEAKERMODE._7POINT1:
-                    switch(Settings.Instance.MeterChannelOrdering)
-                    {
-                    case MeterChannelOrderingType.Standard: // L R | C | LFE | LS RS | LSR RSR
-                        offsets.Add(0); // L
-                        offsets.Add(meterWidth*1); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(meterWidth*3 + groupGap*2); // LFE
-                        offsets.Add(meterWidth*4 + groupGap*3); // LS
-                        offsets.Add(meterWidth*5 + groupGap*3); // RS
-                        offsets.Add(meterWidth*6 + groupGap*4); // LSR
-                        offsets.Add(meterWidth*7 + groupGap*4); // RSR
+                    case FMOD.SPEAKERMODE._7POINT1:
+                        switch (Settings.Instance.MeterChannelOrdering)
+                        {
+                            case MeterChannelOrderingType.Standard: // L R | C | LFE | LS RS | LSR RSR
+                                offsets.Add(0); // L
+                                offsets.Add(meterWidth * 1); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(meterWidth * 3 + groupGap * 2); // LFE
+                                offsets.Add(meterWidth * 4 + groupGap * 3); // LS
+                                offsets.Add(meterWidth * 5 + groupGap * 3); // RS
+                                offsets.Add(meterWidth * 6 + groupGap * 4); // LSR
+                                offsets.Add(meterWidth * 7 + groupGap * 4); // RSR
+                                break;
+                            case MeterChannelOrderingType.SeparateLFE: // L R | C | LS RS | LSR RSR || LFE
+                                offsets.Add(0); // L
+                                offsets.Add(meterWidth * 1); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(meterWidth * 7 + groupGap * 3 + lfeGap); // LFE
+                                offsets.Add(meterWidth * 3 + groupGap * 2); // LS
+                                offsets.Add(meterWidth * 4 + groupGap * 2); // RS
+                                offsets.Add(meterWidth * 5 + groupGap * 3); // LSR
+                                offsets.Add(meterWidth * 6 + groupGap * 3); // RSR
+                                break;
+                            case MeterChannelOrderingType.Positional: // LSR LS | L C R | RS RSR || LFE
+                                offsets.Add(meterWidth * 2 + groupGap); // L
+                                offsets.Add(meterWidth * 4 + groupGap); // R
+                                offsets.Add(meterWidth * 3 + groupGap); // C
+                                offsets.Add(meterWidth * 7 + groupGap * 2 + lfeGap); // LFE
+                                offsets.Add(meterWidth * 1); // LS
+                                offsets.Add(meterWidth * 5 + groupGap * 2); // RS
+                                offsets.Add(0); // LSR
+                                offsets.Add(meterWidth * 6 + groupGap * 2); // RSR
+                                break;
+                        }
                         break;
-                    case MeterChannelOrderingType.SeparateLFE: // L R | C | LS RS | LSR RSR || LFE
-                        offsets.Add(0); // L
-                        offsets.Add(meterWidth*1); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(meterWidth*7 + groupGap*3 + lfeGap); // LFE
-                        offsets.Add(meterWidth*3 + groupGap*2); // LS
-                        offsets.Add(meterWidth*4 + groupGap*2); // RS
-                        offsets.Add(meterWidth*5 + groupGap*3); // LSR
-                        offsets.Add(meterWidth*6 + groupGap*3); // RSR
-                        break;
-                    case MeterChannelOrderingType.Positional: // LSR LS | L C R | RS RSR || LFE
-                        offsets.Add(meterWidth*2 + groupGap); // L
-                        offsets.Add(meterWidth*4 + groupGap); // R
-                        offsets.Add(meterWidth*3 + groupGap); // C
-                        offsets.Add(meterWidth*7 + groupGap*2 + lfeGap); // LFE
-                        offsets.Add(meterWidth*1); // LS
-                        offsets.Add(meterWidth*5 + groupGap*2); // RS
-                        offsets.Add(0); // LSR
-                        offsets.Add(meterWidth*6 + groupGap*2); // RSR
-                        break;
-                    }
-                    break;
 
-                case FMOD.SPEAKERMODE._7POINT1POINT4:
-                    switch(Settings.Instance.MeterChannelOrdering)
-                    {
-                    case MeterChannelOrderingType.Standard: // L R | C | LFE | LS RS | LSR RSR | TFL TFR TBL TBR
-                        offsets.Add(0); // L
-                        offsets.Add(meterWidth*1); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(meterWidth*3 + groupGap*2); // LFE
-                        offsets.Add(meterWidth*4 + groupGap*3); // LS
-                        offsets.Add(meterWidth*5 + groupGap*3); // RS
-                        offsets.Add(meterWidth*6 + groupGap*4); // LSR
-                        offsets.Add(meterWidth*7 + groupGap*4); // RSR
-                        offsets.Add(meterWidth*8 + groupGap*5); // TFL
-                        offsets.Add(meterWidth*9 + groupGap*5); // TFR
-                        offsets.Add(meterWidth*10 + groupGap*5); // TBL
-                        offsets.Add(meterWidth*11 + groupGap*5); // TBR
+                    case FMOD.SPEAKERMODE._7POINT1POINT4:
+                        switch (Settings.Instance.MeterChannelOrdering)
+                        {
+                            case MeterChannelOrderingType.Standard: // L R | C | LFE | LS RS | LSR RSR | TFL TFR TBL TBR
+                                offsets.Add(0); // L
+                                offsets.Add(meterWidth * 1); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(meterWidth * 3 + groupGap * 2); // LFE
+                                offsets.Add(meterWidth * 4 + groupGap * 3); // LS
+                                offsets.Add(meterWidth * 5 + groupGap * 3); // RS
+                                offsets.Add(meterWidth * 6 + groupGap * 4); // LSR
+                                offsets.Add(meterWidth * 7 + groupGap * 4); // RSR
+                                offsets.Add(meterWidth * 8 + groupGap * 5); // TFL
+                                offsets.Add(meterWidth * 9 + groupGap * 5); // TFR
+                                offsets.Add(meterWidth * 10 + groupGap * 5); // TBL
+                                offsets.Add(meterWidth * 11 + groupGap * 5); // TBR
+                                break;
+                            case MeterChannelOrderingType.SeparateLFE: // L R | C | LS RS | LSR RSR | TFL TFR TBL TBR || LFE
+                                offsets.Add(0); // L
+                                offsets.Add(meterWidth * 1); // R
+                                offsets.Add(meterWidth * 2 + groupGap); // C
+                                offsets.Add(meterWidth * 11 + groupGap * 4 + lfeGap); // LFE
+                                offsets.Add(meterWidth * 3 + groupGap * 2); // LS
+                                offsets.Add(meterWidth * 4 + groupGap * 2); // RS
+                                offsets.Add(meterWidth * 5 + groupGap * 3); // LSR
+                                offsets.Add(meterWidth * 6 + groupGap * 3); // RSR
+                                offsets.Add(meterWidth * 7 + groupGap * 4); // TFL
+                                offsets.Add(meterWidth * 8 + groupGap * 4); // TFR
+                                offsets.Add(meterWidth * 9 + groupGap * 4); // TBL
+                                offsets.Add(meterWidth * 10 + groupGap * 4); // TBR
+                                break;
+                            case MeterChannelOrderingType.Positional: // LSR LS | L C R | RS RSR | TBL TFL TFR TBR || LFE
+                                offsets.Add(meterWidth * 2 + groupGap); // L
+                                offsets.Add(meterWidth * 4 + groupGap); // R
+                                offsets.Add(meterWidth * 3 + groupGap); // C
+                                offsets.Add(meterWidth * 11 + groupGap * 3 + lfeGap); // LFE
+                                offsets.Add(meterWidth * 1); // LS
+                                offsets.Add(meterWidth * 5 + groupGap * 2); // RS
+                                offsets.Add(0); // LSR
+                                offsets.Add(meterWidth * 6 + groupGap * 2); // RSR
+                                offsets.Add(meterWidth * 8 + groupGap * 3); // TFL
+                                offsets.Add(meterWidth * 9 + groupGap * 3); // TFR
+                                offsets.Add(meterWidth * 7 + groupGap * 3); // TBL
+                                offsets.Add(meterWidth * 10 + groupGap * 3); // TBR
+                                break;
+                        }
                         break;
-                    case MeterChannelOrderingType.SeparateLFE: // L R | C | LS RS | LSR RSR | TFL TFR TBL TBR || LFE
-                        offsets.Add(0); // L
-                        offsets.Add(meterWidth*1); // R
-                        offsets.Add(meterWidth*2 + groupGap); // C
-                        offsets.Add(meterWidth*11 + groupGap*4 + lfeGap); // LFE
-                        offsets.Add(meterWidth*3 + groupGap*2); // LS
-                        offsets.Add(meterWidth*4 + groupGap*2); // RS
-                        offsets.Add(meterWidth*5 + groupGap*3); // LSR
-                        offsets.Add(meterWidth*6 + groupGap*3); // RSR
-                        offsets.Add(meterWidth*7 + groupGap*4); // TFL
-                        offsets.Add(meterWidth*8 + groupGap*4); // TFR
-                        offsets.Add(meterWidth*9 + groupGap*4); // TBL
-                        offsets.Add(meterWidth*10 + groupGap*4); // TBR
-                        break;
-                    case MeterChannelOrderingType.Positional: // LSR LS | L C R | RS RSR | TBL TFL TFR TBR || LFE
-                        offsets.Add(meterWidth*2 + groupGap); // L
-                        offsets.Add(meterWidth*4 + groupGap); // R
-                        offsets.Add(meterWidth*3 + groupGap); // C
-                        offsets.Add(meterWidth*11 + groupGap*3 + lfeGap); // LFE
-                        offsets.Add(meterWidth*1); // LS
-                        offsets.Add(meterWidth*5 + groupGap*2); // RS
-                        offsets.Add(0); // LSR
-                        offsets.Add(meterWidth*6 + groupGap*2); // RSR
-                        offsets.Add(meterWidth*8 + groupGap*3); // TFL
-                        offsets.Add(meterWidth*9 + groupGap*3); // TFR
-                        offsets.Add(meterWidth*7 + groupGap*3); // TBL
-                        offsets.Add(meterWidth*10 + groupGap*3); // TBR
-                        break;
-                    }
-                    break;
                 }
 
                 return offsets;
@@ -1619,7 +1618,7 @@ namespace FMODUnity
             searchField = new SearchField();
             treeView = new TreeView(treeViewState);
 
-			// Delay accessing the event cache as this will cause an error if window is opened on Unity start up.
+            // Delay accessing the event cache as this will cause an error if window is opened on Unity start up.
             EditorApplication.delayCall += () =>
             {
                 ReadEventCache();

--- a/Assets/Plugins/FMOD/src/Editor/AudioEventBrowser.cs.meta
+++ b/Assets/Plugins/FMOD/src/Editor/AudioEventBrowser.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: b11b989f1afe07e4eb1e3679b562d860
-timeCreated: 1432600216
+guid: 5332ad2baabb58844975479e906001c8
+timeCreated: 1432613753
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Plugins/FMOD/src/Editor/AudioEventCache.cs
+++ b/Assets/Plugins/FMOD/src/Editor/AudioEventCache.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FMODUnity
+{
+    public class AudioEventCache : ScriptableObject
+    {
+        [SerializeField]
+        public List<EditorBankRef> EditorBanks;
+        [SerializeField]
+        public List<EditorEventRef> EditorEvents;
+        [SerializeField]
+        public List<EditorParamRef> EditorParameters;
+        [SerializeField]
+        public List<EditorBankRef> MasterBanks;
+        [SerializeField]
+        public List<EditorBankRef> StringsBanks;
+        [SerializeField]
+        private Int64 cacheTime;
+        [SerializeField]
+        public int cacheVersion;
+
+        public DateTime CacheTime
+        {
+            get { return new DateTime(cacheTime); }
+            set { cacheTime = value.Ticks; }
+        }
+
+        public AudioEventCache()
+        {
+            EditorBanks = new List<EditorBankRef>();
+            EditorEvents = new List<EditorEventRef>();
+            EditorParameters = new List<EditorParamRef>();
+            MasterBanks = new List<EditorBankRef>();
+            StringsBanks = new List<EditorBankRef>();
+            cacheTime = 0;
+        }
+    }
+}

--- a/Assets/Plugins/FMOD/src/Editor/AudioEventCache.cs.meta
+++ b/Assets/Plugins/FMOD/src/Editor/AudioEventCache.cs.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: b11b989f1afe07e4eb1e3679b562d860
-timeCreated: 1432600216
+guid: d32cf7c32a3ed8347bac48ef5ed56d82
+timeCreated: 1432775088
 licenseType: Free
 MonoImporter:
   serializedVersion: 2

--- a/Assets/Plugins/FMOD/src/Editor/AudioEventManager.cs
+++ b/Assets/Plugins/FMOD/src/Editor/AudioEventManager.cs
@@ -12,7 +12,7 @@ using UnityEngine.SceneManagement;
 namespace FMODUnity
 {
     [InitializeOnLoad]
-    public class EventManager : MonoBehaviour
+    public class AudioEventManager : MonoBehaviour
     {
         private const string FMODLabel = "FMOD";
 
@@ -20,7 +20,7 @@ namespace FMODUnity
 
         private const string CacheAssetName = "FMODStudioCache";
         public static string CacheAssetFullName = EditorUtils.WritableAssetPath(CacheAssetName);
-        private static EventCache eventCache;
+        private static AudioEventCache eventCache;
 
         private const string StringBankExtension = "strings.bank";
         private const string BankExtension = "bank";
@@ -68,7 +68,7 @@ namespace FMODUnity
         {
             if (eventCache == null)
             {
-                eventCache = AssetDatabase.LoadAssetAtPath(CacheAssetFullName, typeof(EventCache)) as EventCache;
+                eventCache = AssetDatabase.LoadAssetAtPath(CacheAssetFullName, typeof(AudioEventCache)) as AudioEventCache;
 
                 // If new libraries need to be staged, or the staging process is in progress, clear the cache and exit.
                 if (StagingSystem.SourceLibsExist)
@@ -84,7 +84,7 @@ namespace FMODUnity
                 {
                     RuntimeUtils.DebugLog("FMOD: Event cache is missing or in an old format; creating a new instance.");
 
-                    eventCache = ScriptableObject.CreateInstance<EventCache>();
+                    eventCache = ScriptableObject.CreateInstance<AudioEventCache>();
                     eventCache.cacheVersion = FMOD.VERSION.number;
 
                     Directory.CreateDirectory(Path.GetDirectoryName(CacheAssetFullName));
@@ -382,11 +382,11 @@ namespace FMODUnity
         {
             bool runUpdater = EditorUtility.DisplayDialog("Events Renamed",
                 string.Format("Some events have been renamed in FMOD Studio. Do you want to run {0} " +
-                "to find and update any references to them?", EventReferenceUpdater.MenuPath), "Yes", "No");
+                "to find and update any references to them?", AudioEventReferenceUpdater.MenuPath), "Yes", "No");
 
             if (runUpdater)
             {
-                EventReferenceUpdater.ShowWindow();
+                AudioEventReferenceUpdater.ShowWindow();
             }
         }
 
@@ -564,7 +564,7 @@ namespace FMODUnity
             return labels;
         }
 
-        static EventManager()
+        static AudioEventManager()
         {
             BuildStatusWatcher.OnBuildStarted += () => {
                 BuildTargetChanged();
@@ -618,7 +618,7 @@ namespace FMODUnity
         }
 
         private static readonly string UpdaterInstructions =
-            string.Format("Please run {0} to resolve this issue.", EventReferenceUpdater.MenuPath);
+            string.Format("Please run {0} to resolve this issue.", AudioEventReferenceUpdater.MenuPath);
 
         private static void ValidateEventEmitter(StudioAudioEventEmitter emitter, Scene scene)
         {
@@ -649,7 +649,7 @@ namespace FMODUnity
             foreach (FieldInfo field in fields)
             {
 #pragma warning disable 0618 // Suppress a warning about using the obsolete EventRefAttribute class
-                if (EditorUtils.HasAttribute<EventRefAttribute>(field))
+                if (EditorUtils.HasAttribute<AudioEventRefAttribute>(field))
 #pragma warning restore 0618
                 {
                     RuntimeUtils.DebugLogWarningFormat("FMOD: A component of type {0} in scene '{1}' on GameObject '{2}' has an "

--- a/Assets/Plugins/FMOD/src/Editor/AudioEventManager.cs.meta
+++ b/Assets/Plugins/FMOD/src/Editor/AudioEventManager.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b11b989f1afe07e4eb1e3679b562d860
+guid: 1fc38201a5edb994c874a4a61e96053b
 timeCreated: 1432600216
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/FMOD/src/Editor/AudioEventReferenceUpdater.cs
+++ b/Assets/Plugins/FMOD/src/Editor/AudioEventReferenceUpdater.cs
@@ -5,17 +5,13 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
-using UnityEditor.Experimental.SceneManagement;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-#if UNITY_INPUTSYSTEM_EXIST
-using UnityEngine.InputSystem;
-#endif
 
 namespace FMODUnity
 {
-    public class EventReferenceUpdater : EditorWindow
+    public class AudioEventReferenceUpdater : EditorWindow
     {
         public const string MenuPath = "FMOD/Update Event References";
 
@@ -77,7 +73,7 @@ namespace FMODUnity
         [MenuItem(MenuPath)]
         public static void ShowWindow()
         {
-            EventReferenceUpdater updater = GetWindow<EventReferenceUpdater>("FMOD Event Reference Updater");
+            AudioEventReferenceUpdater updater = GetWindow<AudioEventReferenceUpdater>("FMOD Event Reference Updater");
             updater.minSize = new Vector2(800, 600);
 
             updater.SetStatus(HelpText);
@@ -311,7 +307,7 @@ namespace FMODUnity
                     {
                         if (assetIndex < 0)
                         {
-                            assetIndex = AddAsset(AssetType.Scene,  path);
+                            assetIndex = AddAsset(AssetType.Scene, path);
                         }
 
                         task.AssetIndex = assetIndex;
@@ -434,7 +430,7 @@ namespace FMODUnity
 
             if (Settings.Instance.EventLinkage == EventLinkage.GUID)
             {
-                EditorEventRef editorEventRef = EventManager.EventFromGUID(eventReference.Guid);
+                EditorEventRef editorEventRef = AudioEventManager.EventFromGUID(eventReference.Guid);
 
                 if (editorEventRef == null)
                 {
@@ -449,7 +445,7 @@ namespace FMODUnity
             }
             else if (Settings.Instance.EventLinkage == EventLinkage.Path)
             {
-                EditorEventRef editorEventRef = EventManager.EventFromPath(eventReference.Path);
+                EditorEventRef editorEventRef = AudioEventManager.EventFromPath(eventReference.Path);
 
                 if (editorEventRef != null)
                 {
@@ -461,7 +457,7 @@ namespace FMODUnity
                 }
                 else if (!eventReference.Guid.IsNull)
                 {
-                    editorEventRef = EventManager.EventFromGUID(eventReference.Guid);
+                    editorEventRef = AudioEventManager.EventFromGUID(eventReference.Guid);
 
                     if (editorEventRef != null)
                     {
@@ -506,7 +502,7 @@ namespace FMODUnity
 #pragma warning disable 0618 // Suppress a warning about using the obsolete EventRefAttribute class
         private static bool IsEventRef(FieldInfo field)
         {
-            return field.FieldType == typeof(string) && EditorUtils.HasAttribute<EventRefAttribute>(field);
+            return field.FieldType == typeof(string) && EditorUtils.HasAttribute<AudioEventRefAttribute>(field);
         }
 #pragma warning restore 0618
 
@@ -550,7 +546,7 @@ namespace FMODUnity
             int initialOldFieldCount = oldFields.Count;
 
             // Remove empty [EventRef] fields
-            for (int i = 0; i < oldFields.Count; )
+            for (int i = 0; i < oldFields.Count;)
             {
                 FieldInfo oldField = oldFields[i];
 
@@ -569,7 +565,7 @@ namespace FMODUnity
             // Handle conflicts where multiple [EventRef] fields have the same migration target
 #pragma warning disable 0618 // Suppress a warning about using the obsolete EventRefAttribute class
             IGrouping<string, FieldInfo>[] conflictingGroups = oldFields
-                .GroupBy(f => GetCustomAttribute<EventRefAttribute>(f).MigrateTo)
+                .GroupBy(f => GetCustomAttribute<AudioEventRefAttribute>(f).MigrateTo)
                 .Where(g => !string.IsNullOrEmpty(g.Key) && g.Count() > 1)
                 .ToArray();
 #pragma warning restore 0618
@@ -586,11 +582,11 @@ namespace FMODUnity
 
             // Handle [EventRef] fields with MigrateTo set
 #pragma warning disable 0618 // Suppress a warning about using the obsolete EventRefAttribute class
-            for (int i = 0; i < oldFields.Count; )
+            for (int i = 0; i < oldFields.Count;)
             {
                 FieldInfo oldField = oldFields[i];
 
-                EventRefAttribute attribute = GetCustomAttribute<EventRefAttribute>(oldField);
+                AudioEventRefAttribute attribute = GetCustomAttribute<AudioEventRefAttribute>(oldField);
 
                 if (!string.IsNullOrEmpty(attribute.MigrateTo))
                 {
@@ -685,7 +681,7 @@ namespace FMODUnity
                 {
                     object value = subObjectField.GetValue(target);
                     if (value == null || (value is UnityEngine.Object && !(value as UnityEngine.Object)))
-                    { 
+                    {
                         continue;
                     }
 
@@ -695,7 +691,7 @@ namespace FMODUnity
                         {
                             int index = 0;
                             var valueEnumerator = (value as System.Collections.IEnumerable).GetEnumerator();
-                            for (;;)
+                            for (; ; )
                             {
                                 object item = null;
                                 try
@@ -988,7 +984,8 @@ namespace FMODUnity
                 ExecuteDelegate Execute,
                 ManualInstructionsDelegate ManualInstructions = null)
             {
-                Implementations[(int)type] = new Delegates() {
+                Implementations[(int)type] = new Delegates()
+                {
                     Description = Description,
                     IsValid = IsValid,
                     Execute = Execute,
@@ -1010,14 +1007,17 @@ namespace FMODUnity
 #pragma warning disable 0618
 
                 Implement(Type.EmitterClearEvent,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format("Clear <b>'{0}'</b> from the <b>{1}</b> field", data[0], EmitterEventField);
                     },
-                    IsValid: (data, target) => {
+                    IsValid: (data, target) =>
+                    {
                         StudioAudioEventEmitter emitter = target as StudioAudioEventEmitter;
                         return emitter != null && emitter.Event == data[0] && !emitter.EventReference.IsNull;
                     },
-                    Execute: (data, target) => {
+                    Execute: (data, target) =>
+                    {
                         StudioAudioEventEmitter emitter = target as StudioAudioEventEmitter;
 
                         emitter.Event = string.Empty;
@@ -1025,21 +1025,24 @@ namespace FMODUnity
                     }
                 );
                 Implement(Type.EmitterMoveEventToEventReference,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format("Move <b>'{0}'</b> from <b>{1}</b> to <b>{2}</b>",
                             data[0], EmitterEventField, EmitterEventReferenceField);
                     },
-                    IsValid: (data, target) => {
+                    IsValid: (data, target) =>
+                    {
                         StudioAudioEventEmitter emitter = target as StudioAudioEventEmitter;
                         return emitter != null && emitter.Event == data[0] && emitter.EventReference.IsNull;
                     },
-                    Execute: (data, target) => {
+                    Execute: (data, target) =>
+                    {
                         StudioAudioEventEmitter emitter = target as StudioAudioEventEmitter;
 
                         emitter.EventReference.Path = emitter.Event;
                         emitter.Event = string.Empty;
 
-                        EditorEventRef eventRef = EventManager.EventFromPath(emitter.EventReference.Path);
+                        EditorEventRef eventRef = AudioEventManager.EventFromPath(emitter.EventReference.Path);
 
                         if (eventRef != null)
                         {
@@ -1050,11 +1053,13 @@ namespace FMODUnity
                     }
                 );
                 Implement(Type.EmitterMoveEventOverrideToEventReference,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format("Move prefab override <b>'{0}'</b> from <b>{1}</b> to <b>{2}</b>",
                             data[0], EmitterEventField, EmitterEventReferenceField);
                     },
-                    IsValid: (data, target) => {
+                    IsValid: (data, target) =>
+                    {
                         if (!PrefabUtility.IsPartOfPrefabInstance(target))
                         {
                             return false;
@@ -1093,7 +1098,8 @@ namespace FMODUnity
 
                         return true;
                     },
-                    Execute: (data, target) => {
+                    Execute: (data, target) =>
+                    {
                         StudioAudioEventEmitter emitter = target as StudioAudioEventEmitter;
 
                         string path = emitter.Event;
@@ -1111,7 +1117,7 @@ namespace FMODUnity
                         // Set the EventReference override
                         emitter.EventReference.Path = path;
 
-                        EditorEventRef eventRef = EventManager.EventFromPath(path);
+                        EditorEventRef eventRef = AudioEventManager.EventFromPath(path);
 
                         if (eventRef != null)
                         {
@@ -1124,14 +1130,17 @@ namespace FMODUnity
 
 #if UNITY_TIMELINE_EXIST
                 Implement(Type.PlayableClearEventName,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format("Clear <b>'{0}'</b> from the <b>{1}</b> field", data[0], PlayableEventNameField);
                     },
-                    IsValid: (data, target) => {
+                    IsValid: (data, target) =>
+                    {
                         FMODEventPlayable playable = target as FMODEventPlayable;
                         return playable != null && playable.eventName == data[0] && !playable.EventReference.IsNull;
                     },
-                    Execute: (data, target) => {
+                    Execute: (data, target) =>
+                    {
                         FMODEventPlayable playable = target as FMODEventPlayable;
 
                         playable.eventName = string.Empty;
@@ -1139,21 +1148,24 @@ namespace FMODUnity
                     }
                 );
                 Implement(Type.PlayableMoveEventNameToEventReference,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format("Move <b>'{0}'</b> from <b>{1}</b> to <b>{2}</b>",
                             data[0], PlayableEventNameField, PlayableEventReferenceField);
                     },
-                    IsValid: (data, target) => {
+                    IsValid: (data, target) =>
+                    {
                         FMODEventPlayable playable = target as FMODEventPlayable;
                         return playable != null && playable.eventName == data[0] && playable.EventReference.IsNull;
                     },
-                    Execute: (data, target) => {
+                    Execute: (data, target) =>
+                    {
                         FMODEventPlayable playable = target as FMODEventPlayable;
 
                         playable.EventReference.Path = playable.eventName;
                         playable.eventName = string.Empty;
 
-                        EditorEventRef eventRef = EventManager.EventFromPath(playable.EventReference.Path);
+                        EditorEventRef eventRef = AudioEventManager.EventFromPath(playable.EventReference.Path);
 
                         if (eventRef != null)
                         {
@@ -1165,10 +1177,12 @@ namespace FMODUnity
                 );
 #endif
                 Implement(Type.GenericRemoveEventRefField,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format("Remove field <b>{0}</b>", FieldPath(data[0], data[2]));
                     },
-                    ManualInstructions: (data, component) => {
+                    ManualInstructions: (data, component) =>
+                    {
                         string subObjectPath = data[0];
                         string value = data[1];
                         string fieldName = data[2];
@@ -1183,7 +1197,8 @@ namespace FMODUnity
                             "* Edit the definition of the {3} type and remove the {4} field",
                             fieldPath, component.Type, value, targetType, fieldName);
                     },
-                    IsValid: (data, rootObject) => {
+                    IsValid: (data, rootObject) =>
+                    {
                         object target = FindSubObject(rootObject, data[0]);
 
                         System.Type targetType = target.GetType();
@@ -1194,10 +1209,12 @@ namespace FMODUnity
                     Execute: null
                 );
                 Implement(Type.GenericRemoveEmptyEventRefField,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format("Remove empty field <b>{0}</b>", FieldPath(data[0], data[1]));
                     },
-                    ManualInstructions: (data, component) => {
+                    ManualInstructions: (data, component) =>
+                    {
                         string subObjectPath = data[0];
                         string fieldName = data[1];
                         string targetType = data[2];
@@ -1210,7 +1227,8 @@ namespace FMODUnity
                             "* Edit the definition of the {2} type and remove the {3} field",
                             fieldPath, component.Type, targetType, fieldName);
                     },
-                    IsValid: (data, rootObject) => {
+                    IsValid: (data, rootObject) =>
+                    {
                         object target = FindSubObject(rootObject, data[0]);
 
                         System.Type targetType = target.GetType();
@@ -1222,7 +1240,8 @@ namespace FMODUnity
                     Execute: null
                 );
                 Implement(Type.GenericMoveEventRefFieldToEventReferenceField,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         string subObjectPath = data[0];
                         string value = data[1];
                         string oldFieldPath = FieldPath(subObjectPath, data[2]);
@@ -1231,7 +1250,8 @@ namespace FMODUnity
                         return string.Format("Move <b>'{0}'</b> from <b>{1}</b> to <b>{2}</b>",
                             value, oldFieldPath, newFieldPath);
                     },
-                    IsValid: (data, rootObject) => {
+                    IsValid: (data, rootObject) =>
+                    {
                         string subObjectPath = data[0];
                         string value = data[1];
                         string oldFieldName = data[2];
@@ -1255,7 +1275,8 @@ namespace FMODUnity
 
                         return oldValue == value && newValue.IsNull;
                     },
-                    Execute: (data, rootObject) => {
+                    Execute: (data, rootObject) =>
+                    {
                         string subObjectPath = data[0];
                         string path = data[1];
                         string oldFieldName = data[2];
@@ -1269,7 +1290,7 @@ namespace FMODUnity
 
                         EventReference eventReference = new EventReference() { Path = path };
 
-                        EditorEventRef eventRef = EventManager.EventFromPath(path);
+                        EditorEventRef eventRef = AudioEventManager.EventFromPath(path);
 
                         if (eventRef != null)
                         {
@@ -1283,7 +1304,8 @@ namespace FMODUnity
                     }
                 );
                 Implement(Type.GenericAddMigrationTarget,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         string value = data[1];
                         string fieldPath = FieldPath(data[0], data[2]);
                         string targetName = data[4];
@@ -1300,7 +1322,8 @@ namespace FMODUnity
                                 value, fieldPath);
                         }
                     },
-                    ManualInstructions: (data, component) => {
+                    ManualInstructions: (data, component) =>
+                    {
                         string fieldName = data[2];
                         string targetType = data[3];
                         string targetName = data[4];
@@ -1340,7 +1363,8 @@ namespace FMODUnity
                                 fieldPath, component.Type, script, fieldName);
                         }
                     },
-                    IsValid: (data, rootObject) => {
+                    IsValid: (data, rootObject) =>
+                    {
                         string value = data[1];
                         string oldFieldName = data[2];
 
@@ -1355,13 +1379,15 @@ namespace FMODUnity
                     Execute: null
                 );
                 Implement(Type.GenericUpdateEventReferencePath,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format(
                             "Change the path on field <b>{0}</b> " +
                             "from <b>'{1}'</b> to <b>'{2}'</b> (to match GUID <b>{3}</b>)",
                             FieldPath(data[0], data[1]), data[2], data[3], data[4]);
                     },
-                    IsValid: (data, rootObject) => {
+                    IsValid: (data, rootObject) =>
+                    {
                         object target = FindSubObject(rootObject, data[0]);
 
                         System.Type targetType = target.GetType();
@@ -1376,7 +1402,8 @@ namespace FMODUnity
 
                         return value.Path == data[2] && value.Guid.ToString() == data[4];
                     },
-                    Execute: (data, rootObject) => {
+                    Execute: (data, rootObject) =>
+                    {
                         object target = FindSubObject(rootObject, data[0]);
 
                         System.Type targetType = target.GetType();
@@ -1391,13 +1418,15 @@ namespace FMODUnity
                     }
                 );
                 Implement(Type.GenericUpdateEventReferenceGuid,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         return string.Format(
                             "Change the GUID on field <b>{0}</b> " +
                             "from <b>{1}</b> to <b>{2}</b> (to match path <b>'{3}'</b>)",
                             FieldPath(data[0], data[1]), data[2], data[3], data[4]);
                     },
-                    IsValid: (data, rootObject) => {
+                    IsValid: (data, rootObject) =>
+                    {
                         object target = FindSubObject(rootObject, data[0]);
 
                         System.Type targetType = target.GetType();
@@ -1412,7 +1441,8 @@ namespace FMODUnity
 
                         return value.Guid.ToString() == data[2] && value.Path == data[4];
                     },
-                    Execute: (data, rootObject) => {
+                    Execute: (data, rootObject) =>
+                    {
                         object target = FindSubObject(rootObject, data[0]);
 
                         System.Type targetType = target.GetType();
@@ -1427,14 +1457,16 @@ namespace FMODUnity
                     }
                 );
                 Implement(Type.GenericFixMigrationTargetConflict,
-                    Description: (data) => {
+                    Description: (data) =>
+                    {
                         string subObjectPath = data[0];
                         IEnumerable<string> fieldPaths = data.Skip(2).Select(field => FieldPath(subObjectPath, field));
 
                         return string.Format("Fix conflicting migration targets on fields <b>{0}</b>",
                             EditorUtils.SeriesString("</b>, <b>", "</b> and <b>", fieldPaths));
                     },
-                    ManualInstructions: (data, component) => {
+                    ManualInstructions: (data, component) =>
+                    {
                         return string.Format(
                             "Fields {0} on the {1} type have [EventRef] attributes with the same MigrateTo value.\n" +
                             "* Edit the definition of the {1} type and make sure all [EventRef] attributes have " +
@@ -1442,7 +1474,8 @@ namespace FMODUnity
                             "* Re-scan your project",
                             EditorUtils.SeriesString(", ", " and ", data.Skip(2)), data[1]);
                     },
-                    IsValid: (data, target) => {
+                    IsValid: (data, target) =>
+                    {
                         return true;
                     },
                     Execute: null
@@ -1726,7 +1759,8 @@ namespace FMODUnity
 
         private int AddAsset(AssetType type, string path)
         {
-            Asset asset = new Asset() {
+            Asset asset = new Asset()
+            {
                 Type = type,
                 Path = path,
             };
@@ -1740,7 +1774,8 @@ namespace FMODUnity
         {
             MonoScript script = MonoScript.FromMonoBehaviour(behaviour);
 
-            Component component = new Component() {
+            Component component = new Component()
+            {
                 GameObjectID = GlobalObjectId.GetGlobalObjectIdSlow(behaviour.gameObject),
                 Type = behaviour.GetType().Name,
                 Path = EditorUtils.GameObjectPath(behaviour, root),
@@ -1756,7 +1791,8 @@ namespace FMODUnity
         {
             MonoScript script = MonoScript.FromScriptableObject(scriptableObject);
 
-            Component component = new Component() {
+            Component component = new Component()
+            {
                 Type = scriptableObject.GetType().Name,
                 ScriptPath = AssetDatabase.GetAssetPath(script),
             };
@@ -2218,7 +2254,8 @@ namespace FMODUnity
 
                         if (assetItem == null || assetItem.asset != asset)
                         {
-                            assetItem = new AssetItem() {
+                            assetItem = new AssetItem()
+                            {
                                 id = index++,
                                 asset = asset,
                                 displayName = asset.Path,
@@ -2228,7 +2265,8 @@ namespace FMODUnity
                             root.AddChild(assetItem);
                         }
 
-                        TreeViewItem taskItem = new TaskItem() {
+                        TreeViewItem taskItem = new TaskItem()
+                        {
                             id = index++,
                             task = task,
                         };

--- a/Assets/Plugins/FMOD/src/Editor/AudioEventReferenceUpdater.cs.meta
+++ b/Assets/Plugins/FMOD/src/Editor/AudioEventReferenceUpdater.cs.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
-guid: b11b989f1afe07e4eb1e3679b562d860
-timeCreated: 1432600216
-licenseType: Free
+guid: 0b58df65bd3bb6649801b24a7a942ccb
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0

--- a/Assets/Plugins/FMOD/src/Editor/BankRefDrawer.cs
+++ b/Assets/Plugins/FMOD/src/Editor/BankRefDrawer.cs
@@ -51,7 +51,7 @@ namespace FMODUnity
             EditorGUI.PropertyField(pathRect, pathProperty, GUIContent.none);
             if (GUI.Button(searchRect, new GUIContent(browseIcon, "Select FMOD Bank"), buttonStyle))
             {
-                var eventBrowser = ScriptableObject.CreateInstance<EventBrowser>();
+                var eventBrowser = ScriptableObject.CreateInstance<AudioEventBrowser>();
 
                 eventBrowser.ChooseBank(property);
                 var windowRect = position;

--- a/Assets/Plugins/FMOD/src/Editor/BankRefreshWindow.cs
+++ b/Assets/Plugins/FMOD/src/Editor/BankRefreshWindow.cs
@@ -230,7 +230,7 @@ namespace FMODUnity
 
             if (GUI.Button(refreshRect, "Refresh Banks Now"))
             {
-                EventManager.RefreshBanks();
+                AudioEventManager.RefreshBanks();
             }
         }
     }

--- a/Assets/Plugins/FMOD/src/Editor/BankRefresher.cs
+++ b/Assets/Plugins/FMOD/src/Editor/BankRefresher.cs
@@ -106,9 +106,9 @@ namespace FMODUnity
         {
             if (Time.realtimeSinceStartup >= nextFilePollTime)
             {
-                if (!File.Exists(EventManager.CacheAssetFullName))
+                if (!File.Exists(AudioEventManager.CacheAssetFullName))
                 {
-                    EventManager.RefreshBanks();
+                    AudioEventManager.RefreshBanks();
                 }
 
                 nextFilePollTime = Time.realtimeSinceStartup + FilePollPeriod;
@@ -119,7 +119,7 @@ namespace FMODUnity
         {
             if (TimeUntilBankRefresh() == 0 && BankRefreshWindow.ReadyToRefreshBanks)
             {
-                EventManager.RefreshBanks();
+                AudioEventManager.RefreshBanks();
             }
         }
 

--- a/Assets/Plugins/FMOD/src/Editor/EditorUtils.cs
+++ b/Assets/Plugins/FMOD/src/Editor/EditorUtils.cs
@@ -455,7 +455,7 @@ namespace FMODUnity
                 if (!string.IsNullOrEmpty(behavior.EventReference.Path))
                 {
                     LoadPreviewBanks();
-                    EditorEventRef eventRef = EventManager.EventFromPath(behavior.EventReference.Path);
+                    EditorEventRef eventRef = AudioEventManager.EventFromPath(behavior.EventReference.Path);
                     Dictionary<string, float> paramValues = new Dictionary<string, float>();
                     foreach (EditorParamRef param in eventRef.Parameters)
                     {
@@ -501,7 +501,7 @@ namespace FMODUnity
             BuildStatusWatcher.Startup();
             BankRefresher.Startup();
             BoltIntegration.Startup();
-            EventManager.Startup();
+            AudioEventManager.Startup();
             SetupWizardWindow.Startup();
         }
 
@@ -561,12 +561,12 @@ namespace FMODUnity
 
         public static void UpdateParamsOnEmitter(SerializedObject serializedObject, string path)
         {
-            if (string.IsNullOrEmpty(path) || EventManager.EventFromPath(path) == null)
+            if (string.IsNullOrEmpty(path) || AudioEventManager.EventFromPath(path) == null)
             {
                 return;
             }
 
-            var eventRef = EventManager.EventFromPath(path);
+            var eventRef = AudioEventManager.EventFromPath(path);
             serializedObject.ApplyModifiedProperties();
             if (serializedObject.isEditingMultipleObjects)
             {
@@ -584,7 +584,7 @@ namespace FMODUnity
 
         private static void UpdateParamsOnEmitter(UnityEngine.Object obj, EditorEventRef eventRef)
         {
-            var emitter = obj as StudioEventEmitter;
+            var emitter = obj as StudioAudioEventEmitter;
             if (emitter == null)
             {
                 // Custom game object
@@ -705,7 +705,7 @@ namespace FMODUnity
                 return;
             }
 
-            foreach (var bank in EventManager.Banks)
+            foreach (var bank in AudioEventManager.Banks)
             {
                 FMOD.Studio.Bank previewBank;
                 FMOD.RESULT result = System.loadBankFile(bank.Path, FMOD.Studio.LOAD_BANK_FLAGS.NORMAL, out previewBank);

--- a/Assets/Plugins/FMOD/src/Editor/EventBrowser.cs.meta
+++ b/Assets/Plugins/FMOD/src/Editor/EventBrowser.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5332ad2baabb58844975479e906001c8
+guid: af2bbb81f5e4b7549a77fb598bf198b2
 timeCreated: 1432613753
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/FMOD/src/Editor/EventCache.cs.meta
+++ b/Assets/Plugins/FMOD/src/Editor/EventCache.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d32cf7c32a3ed8347bac48ef5ed56d82
+guid: 52c10e683a8c7b84bb5d6d1d326b41cf
 timeCreated: 1432775088
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/FMOD/src/Editor/EventRefDrawer.cs
+++ b/Assets/Plugins/FMOD/src/Editor/EventRefDrawer.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Linq;
-using System.Text;
-using UnityEngine;
 using UnityEditor;
+using UnityEngine;
 
 namespace FMODUnity
 {
     [CustomPropertyDrawer(typeof(EventReference))]
-    public class EventReferenceDrawer : PropertyDrawer
+    public class AudioEventReferenceDrawer : PropertyDrawer
     {
         private static readonly Texture RepairIcon = EditorUtils.LoadImage("Wrench.png");
         private static readonly Texture WarningIcon = EditorUtils.LoadImage("NotFound.png");
@@ -76,7 +75,7 @@ namespace FMODUnity
 
                 if (GUI.Button(searchRect, new GUIContent(browseIcon, "Search"), buttonStyle))
                 {
-                    var eventBrowser = ScriptableObject.CreateInstance<EventBrowser>();
+                    var eventBrowser = ScriptableObject.CreateInstance<AudioEventBrowser>();
 
                     eventBrowser.ChooseEvent(property);
                     var windowRect = position;
@@ -102,8 +101,8 @@ namespace FMODUnity
                 }
                 if (GUI.Button(openRect, new GUIContent(openIcon, "Open In Browser"), buttonStyle))
                 {
-                    EventBrowser.ShowWindow();
-                    EventBrowser eventBrowser = EditorWindow.GetWindow<EventBrowser>();
+                    AudioEventBrowser.ShowWindow();
+                    AudioEventBrowser eventBrowser = EditorWindow.GetWindow<AudioEventBrowser>();
                     eventBrowser.FrameEvent(pathProperty.stringValue);
                 }
 
@@ -181,15 +180,17 @@ namespace FMODUnity
 
                     if (renamedEvent != null)
                     {
-                        MismatchInfo mismatch = new MismatchInfo() {
+                        MismatchInfo mismatch = new MismatchInfo()
+                        {
                             Message = string.Format("Moved to {0}", renamedEvent.Path),
                             HelpText = string.Format(
                                 "This event has been moved in FMOD Studio.\n" +
                                 "You can click the repair button to update the path to the new location, or run " +
                                 "the <b>{0}</b> command to scan your project for similar issues and fix them all.",
-                                EventReferenceUpdater.MenuPath),
+                                AudioEventReferenceUpdater.MenuPath),
                             RepairTooltip = string.Format("Repair: set path to {0}", renamedEvent.Path),
-                            RepairAction = (p) => {
+                            RepairAction = (p) =>
+                            {
                                 p.FindPropertyRelative("Path").stringValue = renamedEvent.Path;
                             },
                         };
@@ -281,19 +282,21 @@ namespace FMODUnity
 
         private static MismatchInfo GetMismatch(EventReference eventReference, EditorEventRef editorEventRef)
         {
-            if (EventManager.GetEventLinkage(eventReference) == EventLinkage.Path)
+            if (AudioEventManager.GetEventLinkage(eventReference) == EventLinkage.Path)
             {
                 if (eventReference.Guid != editorEventRef.Guid)
                 {
-                    return new MismatchInfo() {
+                    return new MismatchInfo()
+                    {
                         Message = "GUID doesn't match path",
                         HelpText = string.Format(
                             "The GUID on this EventReference doesn't match the path.\n" +
                             "You can click the repair button to update the GUID to match the path, or run the " +
                             "<b>{0}</b> command to scan your project for similar issues and fix them all.",
-                            EventReferenceUpdater.MenuPath),
+                            AudioEventReferenceUpdater.MenuPath),
                         RepairTooltip = string.Format("Repair: set GUID to {0}", editorEventRef.Guid),
-                        RepairAction = (property) => {
+                        RepairAction = (property) =>
+                        {
                             property.FindPropertyRelative("Guid").SetGuid(editorEventRef.Guid);
                         },
                     };
@@ -303,15 +306,17 @@ namespace FMODUnity
             {
                 if (eventReference.Path != editorEventRef.Path)
                 {
-                    return new MismatchInfo() {
+                    return new MismatchInfo()
+                    {
                         Message = "Path doesn't match GUID",
                         HelpText = string.Format(
                             "The path on this EventReference doesn't match the GUID.\n" +
                             "You can click the repair button to update the path to match the GUID, or run the " +
                             "<b>{0}</b> command to scan your project for similar issues and fix them all.",
-                            EventReferenceUpdater.MenuPath),
+                            AudioEventReferenceUpdater.MenuPath),
                         RepairTooltip = string.Format("Repair: set path to '{0}'", editorEventRef.Path),
-                        RepairAction = (property) => {
+                        RepairAction = (property) =>
+                        {
                             property.FindPropertyRelative("Path").stringValue = editorEventRef.Path;
                         },
                     };
@@ -323,7 +328,7 @@ namespace FMODUnity
 
         private static void SetEvent(SerializedProperty property, string path)
         {
-            EditorEventRef eventRef = EventManager.EventFromPath(path);
+            EditorEventRef eventRef = AudioEventManager.EventFromPath(path);
 
             if (eventRef != null)
             {
@@ -347,13 +352,13 @@ namespace FMODUnity
 
         private static EditorEventRef GetEditorEventRef(EventReference eventReference)
         {
-            if (EventManager.GetEventLinkage(eventReference) == EventLinkage.Path)
+            if (AudioEventManager.GetEventLinkage(eventReference) == EventLinkage.Path)
             {
-                return EventManager.EventFromPath(eventReference.Path);
+                return AudioEventManager.EventFromPath(eventReference.Path);
             }
             else // Assume EventLinkage.GUID
             {
-                return EventManager.EventFromGUID(eventReference.Guid);
+                return AudioEventManager.EventFromGUID(eventReference.Guid);
             }
         }
 
@@ -361,7 +366,7 @@ namespace FMODUnity
         {
             if (Settings.Instance.EventLinkage == EventLinkage.Path && !eventReference.Guid.IsNull)
             {
-                EditorEventRef editorEventRef = EventManager.EventFromGUID(eventReference.Guid);
+                EditorEventRef editorEventRef = AudioEventManager.EventFromGUID(eventReference.Guid);
 
                 if (editorEventRef != null && editorEventRef.Path != eventReference.Path)
                 {
@@ -407,7 +412,7 @@ namespace FMODUnity
     }
 
 #pragma warning disable 0618 // Suppress the warning about using the obsolete EventRefAttribute class
-    [CustomPropertyDrawer(typeof(EventRefAttribute))]
+    [CustomPropertyDrawer(typeof(AudioEventRefAttribute))]
 #pragma warning restore 0618
     public class LegacyEventRefDrawer : PropertyDrawer
     {
@@ -419,7 +424,7 @@ namespace FMODUnity
             "* Add a field of type <b>EventReference</b> to this class\n" +
             "* Set the <b>MigrateTo</b> property on the <b>[EventRef]</b> attribute: " +
             "<b>[EventRef(MigrateTo=\"<fieldname>\")]</b>\n" +
-            "* Run the <b>" + EventReferenceUpdater.MenuPath + "</b> command to " +
+            "* Run the <b>" + AudioEventReferenceUpdater.MenuPath + "</b> command to " +
             "automatically migrate values from this field to the <b>EventReference</b> field";
 
         private static readonly Texture InfoIcon = EditorGUIUtility.IconContent("console.infoicon.sml").image;
@@ -464,7 +469,7 @@ namespace FMODUnity
         private GUIContent StatusContent(SerializedProperty property)
         {
 #pragma warning disable 0618 // Suppress the warning about using the obsolete EventRefAttribute class
-            string migrationTarget = (attribute as EventRefAttribute).MigrateTo;
+            string migrationTarget = (attribute as AudioEventRefAttribute).MigrateTo;
 #pragma warning restore 0618
 
             if (string.IsNullOrEmpty(migrationTarget))

--- a/Assets/Plugins/FMOD/src/Editor/EventReferenceUpdater.cs.meta
+++ b/Assets/Plugins/FMOD/src/Editor/EventReferenceUpdater.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0b58df65bd3bb6649801b24a7a942ccb
+guid: a3b80e417efee2d4e9d65e7e08f6badf
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Plugins/FMOD/src/Editor/FMODEventPlayableEditor.cs
+++ b/Assets/Plugins/FMOD/src/Editor/FMODEventPlayableEditor.cs
@@ -74,7 +74,7 @@ namespace FMODUnity
 
                 if (!string.IsNullOrEmpty(eventPath))
                 {
-                    editorEventRef = EventManager.EventFromPath(eventPath);
+                    editorEventRef = AudioEventManager.EventFromPath(eventPath);
                 }
                 else
                 {

--- a/Assets/Plugins/FMOD/src/Editor/FindAndReplace.cs
+++ b/Assets/Plugins/FMOD/src/Editor/FindAndReplace.cs
@@ -14,7 +14,7 @@ namespace FMODUnity
         private string message = "";
         private MessageType messageType = MessageType.None;
         private int lastMatch = -1;
-        private List<StudioEventEmitter> emitters;
+        private List<StudioAudioEventEmitter> emitters;
 
         private bool first = true;
 
@@ -32,7 +32,7 @@ namespace FMODUnity
 
         private void OnHierarchyChange()
         {
-            emitters = new List<StudioEventEmitter>(Resources.FindObjectsOfTypeAll<StudioEventEmitter>());
+            emitters = new List<StudioAudioEventEmitter>(Resources.FindObjectsOfTypeAll<StudioAudioEventEmitter>());
 
             if (!levelScope)
             {
@@ -162,7 +162,7 @@ namespace FMODUnity
             messageType = MessageType.Info;
         }
 
-        private bool ReplaceText(StudioEventEmitter emitter)
+        private bool ReplaceText(StudioAudioEventEmitter emitter)
         {
             int findLength = findText.Length;
             int replaceLength = replaceText.Length;

--- a/Assets/Plugins/FMOD/src/Editor/ParamRefDrawer.cs
+++ b/Assets/Plugins/FMOD/src/Editor/ParamRefDrawer.cs
@@ -68,7 +68,7 @@ namespace FMODUnity
 
             if (GUI.Button(searchRect, new GUIContent(browseIcon, "Search"), buttonStyle))
             {
-                var eventBrowser = ScriptableObject.CreateInstance<EventBrowser>();
+                var eventBrowser = ScriptableObject.CreateInstance<AudioEventBrowser>();
 
                 eventBrowser.ChooseParameter(property);
                 var windowRect = position;

--- a/Assets/Plugins/FMOD/src/Editor/SettingsEditor.cs
+++ b/Assets/Plugins/FMOD/src/Editor/SettingsEditor.cs
@@ -1671,7 +1671,7 @@ namespace FMODUnity
                 if (deleteBanks)
                 {
                     // Delete the old banks
-                    EventManager.RemoveBanks(settings.TargetPath);
+                    AudioEventManager.RemoveBanks(settings.TargetPath);
                 }
 
                 hasBankTargetChanged = true;
@@ -1697,7 +1697,7 @@ namespace FMODUnity
 
             if (newSubFolder != targetSubFolder.stringValue)
             {
-                EventManager.RemoveBanks(settings.TargetPath);
+                AudioEventManager.RemoveBanks(settings.TargetPath);
                 targetSubFolder.stringValue = newSubFolder;
                 hasBankTargetChanged = true;
             }
@@ -1729,9 +1729,9 @@ namespace FMODUnity
 
                     EditorGUILayout.PropertyField(meterChannelOrdering, new GUIContent("Meter Channel Ordering"));
 
-                    if (EditorGUI.EndChangeCheck() && EventBrowser.IsOpen)
+                    if (EditorGUI.EndChangeCheck() && AudioEventBrowser.IsOpen)
                     {
-                        EditorWindow.GetWindow<EventBrowser>("FMOD Events", false).Repaint();
+                        EditorWindow.GetWindow<AudioEventBrowser>("FMOD Events", false).Repaint();
                     }
                 }
             }
@@ -2620,7 +2620,7 @@ namespace FMODUnity
             if (lastSourceBankPath != settings.SourceBankPath)
             {
                 lastSourceBankPath = settings.SourceBankPath;
-                EventManager.RefreshBanks();
+                AudioEventManager.RefreshBanks();
             }
         }
 
@@ -2694,7 +2694,7 @@ namespace FMODUnity
                 sourceProjectPath.stringValue = newPath;
                 sourceBankPath.stringValue = GetBankDirectory(serializedObject);
                 serializedObject.ApplyModifiedProperties();
-                EventManager.RefreshBanks();
+                AudioEventManager.RefreshBanks();
                 return true;
             }
         }
@@ -2719,7 +2719,7 @@ namespace FMODUnity
                 newPath = MakePathRelative(newPath);
                 sourceBankPath.stringValue = newPath;
                 serializedObject.ApplyModifiedProperties();
-                EventManager.RefreshBanks();
+                AudioEventManager.RefreshBanks();
                 return true;
             }
         }

--- a/Assets/Plugins/FMOD/src/Editor/SetupWizard.cs
+++ b/Assets/Plugins/FMOD/src/Editor/SetupWizard.cs
@@ -40,8 +40,8 @@ namespace FMODUnity
                 name: "Update Event References",
                 description: "Find event references that use the obsolete [EventRef] attribute " +
                     "and update them to use the EventReference type.",
-                execute: EventReferenceUpdater.ShowWindow,
-                checkComplete: EventReferenceUpdater.IsUpToDate
+                execute: AudioEventReferenceUpdater.ShowWindow,
+                checkComplete: AudioEventReferenceUpdater.IsUpToDate
             ),
         };
 

--- a/Assets/Plugins/FMOD/src/Editor/StudioBankLoaderEditor.cs
+++ b/Assets/Plugins/FMOD/src/Editor/StudioBankLoaderEditor.cs
@@ -35,7 +35,7 @@ namespace FMODUnity
                 SerializedProperty newBank = banks.GetArrayElementAtIndex(banks.arraySize - 1);
                 newBank.stringValue = "";
 
-                EventBrowser browser = CreateInstance<EventBrowser>();
+                AudioEventBrowser browser = CreateInstance<AudioEventBrowser>();
 
                 browser.titleContent = new GUIContent("Select FMOD Bank");
 

--- a/Assets/Plugins/FMOD/src/Editor/StudioEventEmitterEditor.cs
+++ b/Assets/Plugins/FMOD/src/Editor/StudioEventEmitterEditor.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace FMODUnity
 {
-    [CustomEditor(typeof(StudioEventEmitter))]
+    [CustomEditor(typeof(StudioAudioEventEmitter))]
     [CanEditMultipleObjects]
     public class StudioEventEmitterEditor : Editor
     {
@@ -19,9 +19,9 @@ namespace FMODUnity
 
         public void OnSceneGUI()
         {
-            var emitter = target as StudioEventEmitter;
+            var emitter = target as StudioAudioEventEmitter;
 
-            EditorEventRef editorEvent = EventManager.EventFromGUID(emitter.EventReference.Guid);
+            EditorEventRef editorEvent = AudioEventManager.EventFromGUID(emitter.EventReference.Guid);
             if (editorEvent != null && editorEvent.Is3D)
             {
                 EditorGUI.BeginChangeCheck();
@@ -70,7 +70,7 @@ namespace FMODUnity
 
             EditorGUILayout.PropertyField(eventReference, new GUIContent(EventReferenceLabel));
 
-            EditorEventRef editorEvent = EventManager.EventFromPath(eventPath.stringValue);
+            EditorEventRef editorEvent = AudioEventManager.EventFromPath(eventPath.stringValue);
 
             if (EditorGUI.EndChangeCheck())
             {
@@ -491,7 +491,7 @@ namespace FMODUnity
             {
                 foreach (SerializedObject serializedTarget in serializedTargets)
                 {
-                    StudioEventEmitter emitter = serializedTarget.targetObject as StudioEventEmitter;
+                    StudioAudioEventEmitter emitter = serializedTarget.targetObject as StudioAudioEventEmitter;
 
                     if (Array.FindIndex(emitter.Params, p => p.Name == parameter.Name) < 0)
                     {

--- a/Assets/Plugins/FMOD/src/Editor/StudioEventEmitterGizmoDrawer.cs
+++ b/Assets/Plugins/FMOD/src/Editor/StudioEventEmitterGizmoDrawer.cs
@@ -3,10 +3,10 @@ using UnityEditor;
 
 namespace FMODUnity
 {
-    public class StudioEventEmitterGizoDrawer
+    public class StudioAudioEventEmitterGizmosDrawer
     {
         [DrawGizmo(GizmoType.Selected | GizmoType.Active | GizmoType.NotInSelectionHierarchy | GizmoType.Pickable)]
-        private static void DrawGizmo(StudioEventEmitter studioEmitter, GizmoType gizmoType)
+        private static void DrawGizmo(StudioAudioEventEmitter studioEmitter, GizmoType gizmoType)
         {
             Gizmos.DrawIcon(studioEmitter.transform.position, "AudioSource Gizmo", true, Color.yellow);
         }

--- a/Assets/Plugins/FMOD/src/Editor/StudioGlobalParameterTriggerEditor.cs
+++ b/Assets/Plugins/FMOD/src/Editor/StudioGlobalParameterTriggerEditor.cs
@@ -58,7 +58,7 @@ namespace FMODUnity
                 }
                 else
                 {
-                    editorParamRef = EventManager.ParamFromPath(param.stringValue);
+                    editorParamRef = AudioEventManager.ParamFromPath(param.stringValue);
                     value.floatValue = Mathf.Clamp(value.floatValue, editorParamRef.Min, editorParamRef.Max);
                 }
             }

--- a/Assets/Plugins/FMOD/src/Editor/StudioParameterTriggerEditor.cs
+++ b/Assets/Plugins/FMOD/src/Editor/StudioParameterTriggerEditor.cs
@@ -7,7 +7,7 @@ namespace FMODUnity
     [CustomEditor(typeof(StudioParameterTrigger))]
     public class StudioParameterTriggerEditor : Editor
     {
-        private StudioEventEmitter targetEmitter;
+        private StudioAudioEventEmitter targetEmitter;
         private SerializedProperty emitters;
         private SerializedProperty trigger;
         private SerializedProperty tag;
@@ -22,10 +22,10 @@ namespace FMODUnity
             targetEmitter = null;
             for (int i = 0; i < emitters.arraySize; i++)
             {
-                targetEmitter = emitters.GetArrayElementAtIndex(i).FindPropertyRelative("Target").objectReferenceValue as StudioEventEmitter;
+                targetEmitter = emitters.GetArrayElementAtIndex(i).FindPropertyRelative("Target").objectReferenceValue as StudioAudioEventEmitter;
                 if (targetEmitter != null)
                 {
-                    expanded = new bool[targetEmitter.GetComponents<StudioEventEmitter>().Length];
+                    expanded = new bool[targetEmitter.GetComponents<StudioAudioEventEmitter>().Length];
                     break;
                 }
             }
@@ -33,7 +33,7 @@ namespace FMODUnity
 
         public override void OnInspectorGUI()
         {
-            var newTargetEmitter = EditorGUILayout.ObjectField("Target", targetEmitter, typeof(StudioEventEmitter), true) as StudioEventEmitter;
+            var newTargetEmitter = EditorGUILayout.ObjectField("Target", targetEmitter, typeof(StudioAudioEventEmitter), true) as StudioAudioEventEmitter;
             if (newTargetEmitter != targetEmitter)
             {
                 emitters.ClearArray();
@@ -45,7 +45,7 @@ namespace FMODUnity
                     return;
                 }
 
-                List<StudioEventEmitter> newEmitters = new List<StudioEventEmitter>();
+                List<StudioAudioEventEmitter> newEmitters = new List<StudioAudioEventEmitter>();
                 targetEmitter.GetComponents(newEmitters);
                 expanded = new bool[newEmitters.Count];
                 foreach (var emitter in newEmitters)
@@ -67,7 +67,7 @@ namespace FMODUnity
                 tag.stringValue = EditorGUILayout.TagField("Collision Tag", tag.stringValue);
             }
 
-            var localEmitters = new List<StudioEventEmitter>();
+            var localEmitters = new List<StudioAudioEventEmitter>();
             targetEmitter.GetComponents(localEmitters);
 
             int emitterIndex = 0;
@@ -96,7 +96,7 @@ namespace FMODUnity
                     expanded[emitterIndex] = EditorGUILayout.Foldout(expanded[emitterIndex], emitter.EventReference.Path);
                     if (expanded[emitterIndex])
                     {
-                        var eventRef = EventManager.EventFromGUID(emitter.EventReference.Guid);
+                        var eventRef = AudioEventManager.EventFromGUID(emitter.EventReference.Guid);
 
                         foreach (var paramRef in eventRef.LocalParameters)
                         {

--- a/Assets/Plugins/FMOD/src/EventRefAttribute.cs.meta
+++ b/Assets/Plugins/FMOD/src/EventRefAttribute.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1b29a1189268c3b47aa2ec4b96a9e7ef
+guid: 6a9a9e298198cba499a886ec661c6ef3
 timeCreated: 1445311748
 licenseType: Free
 MonoImporter:

--- a/Assets/Plugins/FMOD/src/RuntimeManager.cs
+++ b/Assets/Plugins/FMOD/src/RuntimeManager.cs
@@ -461,7 +461,7 @@ retry:
                     RuntimeUtils.DebugLogWarning("[FMOD] Please add an 'FMOD Studio Listener' component to your camera in the scene for correct 3D positioning of sounds.");
                 }
 
-                StudioEventEmitter.UpdateActiveEmitters();
+                StudioAudioEventEmitter.UpdateActiveEmitters();
 
                 for (int i = 0; i < attachedInstances.Count; i++)
                 {
@@ -1157,7 +1157,7 @@ retry:
                 var result = Instance.studioSystem.lookupID(path, out guid);
                 if (result == FMOD.RESULT.ERR_EVENT_NOTFOUND)
                 {
-                    throw new EventNotFoundException(path);
+                    throw new AudioEventNotFoundException(path);
                 }
             }
             return guid;
@@ -1171,7 +1171,7 @@ retry:
             {
                 guid = PathToGUID(path);
             }
-            catch (EventNotFoundException)
+            catch (AudioEventNotFoundException)
             {
                 guid = new FMOD.GUID();
             }
@@ -1189,9 +1189,9 @@ retry:
             {
                 return CreateInstance(eventReference.Guid);
             }
-            catch (EventNotFoundException)
+            catch (AudioEventNotFoundException)
             {
-                throw new EventNotFoundException(eventReference);
+                throw new AudioEventNotFoundException(eventReference);
             }
         }
 
@@ -1201,10 +1201,10 @@ retry:
             {
                 return CreateInstance(PathToGUID(path));
             }
-            catch(EventNotFoundException)
+            catch(AudioEventNotFoundException)
             {
                 // Switch from exception with GUID to exception with path
-                throw new EventNotFoundException(path);
+                throw new AudioEventNotFoundException(path);
             }
         }
 
@@ -1234,7 +1234,7 @@ retry:
             {
                 PlayOneShot(eventReference.Guid, position);
             }
-            catch (EventNotFoundException)
+            catch (AudioEventNotFoundException)
             {
                 RuntimeUtils.DebugLogWarning("[FMOD] Event not found: " + eventReference);
             }
@@ -1246,7 +1246,7 @@ retry:
             {
                 PlayOneShot(PathToGUID(path), position);
             }
-            catch (EventNotFoundException)
+            catch (AudioEventNotFoundException)
             {
                 RuntimeUtils.DebugLogWarning("[FMOD] Event not found: " + path);
             }
@@ -1266,7 +1266,7 @@ retry:
             {
                 PlayOneShotAttached(eventReference.Guid, gameObject);
             }
-            catch (EventNotFoundException)
+            catch (AudioEventNotFoundException)
             {
                 RuntimeUtils.DebugLogWarning("[FMOD] Event not found: " + eventReference);
             }
@@ -1278,7 +1278,7 @@ retry:
             {
                 PlayOneShotAttached(PathToGUID(path), gameObject);
             }
-            catch (EventNotFoundException)
+            catch (AudioEventNotFoundException)
             {
                 RuntimeUtils.DebugLogWarning("[FMOD] Event not found: " + path);
             }
@@ -1304,9 +1304,9 @@ retry:
             {
                 return GetEventDescription(eventReference.Guid);
             }
-            catch (EventNotFoundException)
+            catch (AudioEventNotFoundException)
             {
-                throw new EventNotFoundException(eventReference);
+                throw new AudioEventNotFoundException(eventReference);
             }
         }
 
@@ -1316,9 +1316,9 @@ retry:
             {
                 return GetEventDescription(PathToGUID(path));
             }
-            catch (EventNotFoundException)
+            catch (AudioEventNotFoundException)
             {
-                throw new EventNotFoundException(path);
+                throw new AudioEventNotFoundException(path);
             }
         }
 
@@ -1335,7 +1335,7 @@ retry:
 
                 if (result != FMOD.RESULT.OK)
                 {
-                    throw new EventNotFoundException(guid);
+                    throw new AudioEventNotFoundException(guid);
                 }
 
                 if (eventDesc.isValid())

--- a/Assets/Plugins/FMOD/src/RuntimeUtils.cs
+++ b/Assets/Plugins/FMOD/src/RuntimeUtils.cs
@@ -89,24 +89,24 @@ namespace FMOD
 
 namespace FMODUnity
 {
-    public class EventNotFoundException : Exception
+    public class AudioEventNotFoundException : Exception
     {
         public FMOD.GUID Guid;
         public string Path;
 
-        public EventNotFoundException(string path)
+        public AudioEventNotFoundException(string path)
             : base("[FMOD] Event not found: '" + path + "'")
         {
             Path = path;
         }
 
-        public EventNotFoundException(FMOD.GUID guid)
+        public AudioEventNotFoundException(FMOD.GUID guid)
             : base("[FMOD] Event not found: " + guid)
         {
             Guid = guid;
         }
 
-        public EventNotFoundException(EventReference eventReference)
+        public AudioEventNotFoundException(EventReference eventReference)
             : base("[FMOD] Event not found: " + eventReference.ToString())
         {
             Guid = eventReference.Guid;

--- a/Assets/Plugins/FMOD/src/StudioAudioEventEmitter.cs
+++ b/Assets/Plugins/FMOD/src/StudioAudioEventEmitter.cs
@@ -1,0 +1,409 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace FMODUnity
+{
+    [AddComponentMenu("FMOD Studio/FMOD Studio Event Emitter")]
+    public class StudioAudioEventEmitter : EventHandler
+    {
+        public EventReference EventReference;
+
+        [Obsolete("Use the EventReference field instead.")]
+        public string Event = "";
+
+        [FormerlySerializedAs("PlayEvent")]
+        public EmitterGameEvent EventPlayTrigger = EmitterGameEvent.None;
+        public EmitterGameEvent PlayEvent
+        {
+            get { return EventPlayTrigger; }
+            set { EventPlayTrigger = value; }
+        }
+        [FormerlySerializedAs("StopEvent")]
+        public EmitterGameEvent EventStopTrigger = EmitterGameEvent.None;
+        public EmitterGameEvent StopEvent
+        {
+            get { return EventStopTrigger; }
+            set { EventStopTrigger = value; }
+        }
+        public bool AllowFadeout = true;
+        public bool TriggerOnce = false;
+        public bool Preload = false;
+        [FormerlySerializedAs("AllowNonRigidbodyDoppler")]
+        public bool NonRigidbodyVelocity = false;
+        public ParamRef[] Params = new ParamRef[0];
+        public bool OverrideAttenuation = false;
+        public float OverrideMinDistance = -1.0f;
+        public float OverrideMaxDistance = -1.0f;
+
+        protected FMOD.Studio.EventDescription eventDescription;
+
+        protected FMOD.Studio.EventInstance instance;
+
+        private bool hasTriggered = false;
+        private bool isQuitting = false;
+        private bool isOneshot = false;
+        private List<ParamRef> cachedParams = new List<ParamRef>();
+
+        private static List<StudioAudioEventEmitter> activeEmitters = new List<StudioAudioEventEmitter>();
+
+        private const string SnapshotString = "snapshot";
+
+        public FMOD.Studio.EventDescription EventDescription { get { return eventDescription; } }
+
+        public FMOD.Studio.EventInstance EventInstance { get { return instance; } }
+
+        public bool IsActive { get; private set; }
+
+        private float MaxDistance
+        {
+            get
+            {
+                if (OverrideAttenuation)
+                {
+                    return OverrideMaxDistance;
+                }
+
+                if (!eventDescription.isValid())
+                {
+                    Lookup();
+                }
+
+                float minDistance, maxDistance;
+                eventDescription.getMinMaxDistance(out minDistance, out maxDistance);
+                return maxDistance;
+            }
+        }
+
+        public static void UpdateActiveEmitters()
+        {
+            foreach (StudioAudioEventEmitter emitter in activeEmitters)
+            {
+                emitter.UpdatePlayingStatus();
+            }
+        }
+
+        private static void RegisterActiveEmitter(StudioAudioEventEmitter emitter)
+        {
+            if (!activeEmitters.Contains(emitter))
+            {
+                activeEmitters.Add(emitter);
+            }
+        }
+
+        private static void DeregisterActiveEmitter(StudioAudioEventEmitter emitter)
+        {
+            activeEmitters.Remove(emitter);
+        }
+
+        private void UpdatePlayingStatus(bool force = false)
+        {
+            // If at least one listener is within the max distance, ensure an event instance is playing
+            bool playInstance = StudioListener.DistanceSquaredToNearestListener(transform.position) <= (MaxDistance * MaxDistance);
+
+            if (force || playInstance != IsPlaying())
+            {
+                if (playInstance)
+                {
+                    PlayInstance();
+                }
+                else
+                {
+                    StopInstance();
+                }
+            }
+        }
+
+        protected override void Start()
+        {
+            RuntimeUtils.EnforceLibraryOrder();
+            if (Preload)
+            {
+                Lookup();
+                eventDescription.loadSampleData();
+            }
+
+            HandleGameEvent(EmitterGameEvent.ObjectStart);
+
+            // If a Rigidbody or Rigidbody2D is present on this GameObject, turn off "NonRigidbodyVelocity"
+#if UNITY_PHYSICS_EXIST
+            if (NonRigidbodyVelocity && GetComponent<Rigidbody>())
+            {
+                Debug.LogWarning(string.Format("[FMOD] Non-Rigidbody Velocity is enabled on Emitter attached to GameObject \"{0}\", which also has a Rigidbody component attached - this will be disabled in favor of velocity from Rigidbody component.", this.name));
+                NonRigidbodyVelocity = false;
+            }
+#endif
+#if UNITY_PHYSICS2D_EXIST
+            if (NonRigidbodyVelocity && GetComponent<Rigidbody2D>())
+            {
+                Debug.LogWarning(string.Format("[FMOD] Non-Rigidbody Velocity is enabled on Emitter attached to GameObject \"{0}\", which also has a Rigidbody2D component attached - this will be disabled in favor of velocity from Rigidbody2D component.", this.name));
+                NonRigidbodyVelocity = false;
+            }
+#endif
+        }
+
+        private void OnApplicationQuit()
+        {
+            isQuitting = true;
+        }
+
+        protected override void OnDestroy()
+        {
+            if (!isQuitting)
+            {
+                HandleGameEvent(EmitterGameEvent.ObjectDestroy);
+
+                if (instance.isValid())
+                {
+                    RuntimeManager.DetachInstanceFromGameObject(instance);
+                    if (eventDescription.isValid() && isOneshot)
+                    {
+                        instance.release();
+                        instance.clearHandle();
+                    }
+                }
+
+                DeregisterActiveEmitter(this);
+
+                if (Preload)
+                {
+                    eventDescription.unloadSampleData();
+                }
+            }
+        }
+
+        protected override void HandleGameEvent(EmitterGameEvent gameEvent)
+        {
+            if (EventPlayTrigger == gameEvent)
+            {
+                Play();
+            }
+            if (EventStopTrigger == gameEvent)
+            {
+                Stop();
+            }
+        }
+
+        private void Lookup()
+        {
+            eventDescription = RuntimeManager.GetEventDescription(EventReference);
+
+            if (eventDescription.isValid())
+            {
+                for (int i = 0; i < Params.Length; i++)
+                {
+                    FMOD.Studio.PARAMETER_DESCRIPTION param;
+                    eventDescription.getParameterDescriptionByName(Params[i].Name, out param);
+                    Params[i].ID = param.id;
+                }
+            }
+        }
+
+        public void Play()
+        {
+            if (TriggerOnce && hasTriggered)
+            {
+                return;
+            }
+
+            if (EventReference.IsNull)
+            {
+                return;
+            }
+
+            cachedParams.Clear();
+
+            if (!eventDescription.isValid())
+            {
+                Lookup();
+            }
+
+            bool isSnapshot;
+            eventDescription.isSnapshot(out isSnapshot);
+
+            if (!isSnapshot)
+            {
+                eventDescription.isOneshot(out isOneshot);
+            }
+
+            bool is3D;
+            eventDescription.is3D(out is3D);
+
+            IsActive = true;
+
+            if (is3D && !isOneshot && Settings.Instance.StopEventsOutsideMaxDistance)
+            {
+                RegisterActiveEmitter(this);
+                UpdatePlayingStatus(true);
+            }
+            else
+            {
+                PlayInstance();
+            }
+        }
+
+        private void PlayInstance()
+        {
+            if (!instance.isValid())
+            {
+                instance.clearHandle();
+            }
+
+            // Let previous oneshot instances play out
+            if (isOneshot && instance.isValid())
+            {
+                instance.release();
+                instance.clearHandle();
+            }
+
+            bool is3D;
+            eventDescription.is3D(out is3D);
+
+            if (!instance.isValid())
+            {
+                eventDescription.createInstance(out instance);
+
+                // Only want to update if we need to set 3D attributes
+                if (is3D)
+                {
+                    var transform = GetComponent<Transform>();
+#if UNITY_PHYSICS_EXIST
+                    if (GetComponent<Rigidbody>())
+                    {
+                        Rigidbody rigidBody = GetComponent<Rigidbody>();
+                        instance.set3DAttributes(RuntimeUtils.To3DAttributes(gameObject, rigidBody));
+                        RuntimeManager.AttachInstanceToGameObject(instance, gameObject, rigidBody);
+                    }
+                    else
+#endif
+#if UNITY_PHYSICS2D_EXIST
+                    if (GetComponent<Rigidbody2D>())
+                    {
+                        var rigidBody2D = GetComponent<Rigidbody2D>();
+                        instance.set3DAttributes(RuntimeUtils.To3DAttributes(gameObject, rigidBody2D));
+                        RuntimeManager.AttachInstanceToGameObject(instance, gameObject, rigidBody2D);
+                    }
+                    else
+#endif
+                    {
+                        instance.set3DAttributes(RuntimeUtils.To3DAttributes(gameObject));
+                        RuntimeManager.AttachInstanceToGameObject(instance, gameObject, NonRigidbodyVelocity);
+                    }
+                }
+            }
+
+            foreach (var param in Params)
+            {
+                instance.setParameterByID(param.ID, param.Value);
+            }
+
+            foreach (var cachedParam in cachedParams)
+            {
+                instance.setParameterByID(cachedParam.ID, cachedParam.Value);
+            }
+
+            if (is3D && OverrideAttenuation)
+            {
+                instance.setProperty(FMOD.Studio.EVENT_PROPERTY.MINIMUM_DISTANCE, OverrideMinDistance);
+                instance.setProperty(FMOD.Studio.EVENT_PROPERTY.MAXIMUM_DISTANCE, OverrideMaxDistance);
+            }
+
+            instance.start();
+
+            hasTriggered = true;
+        }
+
+        public void Stop()
+        {
+            DeregisterActiveEmitter(this);
+            IsActive = false;
+            cachedParams.Clear();
+            StopInstance();
+        }
+
+        private void StopInstance()
+        {
+            if (TriggerOnce && hasTriggered)
+            {
+                DeregisterActiveEmitter(this);
+            }
+
+            if (instance.isValid())
+            {
+                instance.stop(AllowFadeout ? FMOD.Studio.STOP_MODE.ALLOWFADEOUT : FMOD.Studio.STOP_MODE.IMMEDIATE);
+                instance.release();
+                if (!AllowFadeout)
+                {
+                    instance.clearHandle();
+                }
+            }
+        }
+
+        public void SetParameter(string name, float value, bool ignoreseekspeed = false)
+        {
+            if (Settings.Instance.StopEventsOutsideMaxDistance && IsActive)
+            {
+                string findName = name;
+                ParamRef cachedParam = cachedParams.Find(x => x.Name == findName);
+
+                if (cachedParam == null)
+                {
+                    FMOD.Studio.PARAMETER_DESCRIPTION paramDesc;
+                    eventDescription.getParameterDescriptionByName(name, out paramDesc);
+
+                    cachedParam = new ParamRef();
+                    cachedParam.ID = paramDesc.id;
+                    cachedParam.Name = paramDesc.name;
+                    cachedParams.Add(cachedParam);
+                }
+
+                cachedParam.Value = value;
+            }
+
+            if (instance.isValid())
+            {
+                instance.setParameterByName(name, value, ignoreseekspeed);
+            }
+        }
+
+        public void SetParameter(FMOD.Studio.PARAMETER_ID id, float value, bool ignoreseekspeed = false)
+        {
+            if (Settings.Instance.StopEventsOutsideMaxDistance && IsActive)
+            {
+                FMOD.Studio.PARAMETER_ID findId = id;
+                ParamRef cachedParam = cachedParams.Find(x => x.ID.Equals(findId));
+
+                if (cachedParam == null)
+                {
+                    FMOD.Studio.PARAMETER_DESCRIPTION paramDesc;
+                    eventDescription.getParameterDescriptionByID(id, out paramDesc);
+
+                    cachedParam = new ParamRef();
+                    cachedParam.ID = paramDesc.id;
+                    cachedParam.Name = paramDesc.name;
+                    cachedParams.Add(cachedParam);
+                }
+
+                cachedParam.Value = value;
+            }
+
+            if (instance.isValid())
+            {
+                instance.setParameterByID(id, value, ignoreseekspeed);
+            }
+        }
+
+        public bool IsPlaying()
+        {
+            if (instance.isValid())
+            {
+                FMOD.Studio.PLAYBACK_STATE playbackState;
+                instance.getPlaybackState(out playbackState);
+                return (playbackState != FMOD.Studio.PLAYBACK_STATE.STOPPED);
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/Plugins/FMOD/src/StudioAudioEventEmitter.cs.meta
+++ b/Assets/Plugins/FMOD/src/StudioAudioEventEmitter.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
-guid: b11b989f1afe07e4eb1e3679b562d860
-timeCreated: 1432600216
+guid: 9a6610d2e704f1648819acc8d7460285
+timeCreated: 1444629021
 licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -220
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Plugins/FMOD/src/StudioParameterTrigger.cs
+++ b/Assets/Plugins/FMOD/src/StudioParameterTrigger.cs
@@ -6,7 +6,7 @@ namespace FMODUnity
     [Serializable]
     public class EmitterRef
     {
-        public StudioEventEmitter Target;
+        public StudioAudioEventEmitter Target;
         public ParamRef[] Params;
     }
 


### PR DESCRIPTION
Even tho FMOD uses the "Event" keyword, it is a reserved keyword on C# and it can cause lots of confusion, things like "EventReference" can be confused with C#/Unity events, this pull request aims to change classes named "Event" to "AudioEvent" to be more clear about which kind of event this is.
There was also a misspelling in the "StudioEventEmitterGizoDrawer", it is supposed to be "Gizmos" instead of "Gizo", even tho it's not in the plural.