### PR TITLE
Added support for NativeArray in LoadBank using TextAsset.

### DIFF
--- a/Assets/Plugins/FMOD/FMODUnity.asmdef
+++ b/Assets/Plugins/FMOD/FMODUnity.asmdef
@@ -8,7 +8,7 @@
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/Assets/Plugins/FMOD/src/RuntimeManager.cs
+++ b/Assets/Plugins/FMOD/src/RuntimeManager.cs
@@ -995,7 +995,15 @@ retry:
 #endif
 
                 LoadedBank loadedBank = new LoadedBank();
-                FMOD.RESULT loadResult = Instance.studioSystem.loadBankMemory(asset.bytes, FMOD.Studio.LOAD_BANK_FLAGS.NORMAL, out loadedBank.Bank);
+                FMOD.RESULT loadResult;
+#if UNITY_2021_3_OR_NEWER
+                using (var nativeArray = asset.GetData<byte>())
+                {
+                    loadResult = Instance.studioSystem.loadBankNativeArray(nativeArray, FMOD.Studio.LOAD_BANK_FLAGS.NORMAL, out loadedBank.Bank);
+                }
+#else
+                loadResult = Instance.studioSystem.loadBankMemory(asset.bytes, FMOD.Studio.LOAD_BANK_FLAGS.NORMAL, out loadedBank.Bank);
+#endif
                 Instance.RegisterLoadedBank(loadedBank, bankId, bankId, loadSamples, loadResult);
             }
         }

--- a/Assets/Plugins/FMOD/src/fmod_studio.cs
+++ b/Assets/Plugins/FMOD/src/fmod_studio.cs
@@ -11,6 +11,11 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Collections;
 
+#if UNITY_2021_3_OR_NEWER
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+#endif
+
 namespace FMOD.Studio
 {
     public partial class STUDIO_VERSION
@@ -677,6 +682,14 @@ namespace FMOD.Studio
             pinnedArray.Free();
             return result;
         }
+#if UNITY_2021_3_OR_NEWER
+        public unsafe RESULT loadBankNativeArray(NativeArray<byte> buffer, LOAD_BANK_FLAGS flags, out Bank bank)
+        {
+            IntPtr pointer = (IntPtr)buffer.GetUnsafeReadOnlyPtr();
+            RESULT result = FMOD_Studio_System_LoadBankMemory(this.handle, pointer, buffer.Length, LOAD_MEMORY_MODE.LOAD_MEMORY, flags, out bank.handle);
+            return result;
+        }
+#endif
         public RESULT loadBankCustom(BANK_INFO info, LOAD_BANK_FLAGS flags, out Bank bank)
         {
             info.size = Marshal.SizeOf<BANK_INFO>();


### PR DESCRIPTION
저는 FMOD 로딩을 TextAsset 으로 사용하고 있는데,
유니티 최신 버전에서는 GetData<T> API를 통해서 추가 버퍼 할당 없이 로드할 수 있으면 좋을 것 같아요.

I'm using FMOD to load TextAssets, and I'd like to be able to load them without allocating additional buffers using the GetData<T> API in the latest version of Unity.

<img width="1846" height="495" alt="before" src="https://github.com/user-attachments/assets/d5ec22f2-71cd-4ab1-b704-38d417cebb13" />

<img width="1850" height="503" alt="after" src="https://github.com/user-attachments/assets/0695cbdb-1873-43ff-8b95-18757d7eafd2" />
