### PR TITLE
Improvement/runtime optimizations

### DIFF
--- a/Assets/Plugins/FMOD/src/RuntimeUtils.cs
+++ b/Assets/Plugins/FMOD/src/RuntimeUtils.cs
@@ -367,20 +367,22 @@ namespace FMODUnity
 
         public static FMOD.ATTRIBUTES_3D To3DAttributes(this Transform transform)
         {
+            transform.GetPositionAndRotation(out Vector3 position, out Quaternion rotation);
             FMOD.ATTRIBUTES_3D attributes = new FMOD.ATTRIBUTES_3D();
-            attributes.forward = transform.forward.ToFMODVector();
-            attributes.up = transform.up.ToFMODVector();
-            attributes.position = transform.position.ToFMODVector();
+            attributes.forward = (rotation * Vector3.forward).ToFMODVector();
+            attributes.up = (rotation * Vector3.up).ToFMODVector();
+            attributes.position = position.ToFMODVector();
 
             return attributes;
         }
 
         public static FMOD.ATTRIBUTES_3D To3DAttributes(this Transform transform, Vector3 velocity)
         {
+            transform.GetPositionAndRotation(out Vector3 position, out Quaternion rotation);
             FMOD.ATTRIBUTES_3D attributes = new FMOD.ATTRIBUTES_3D();
-            attributes.forward = transform.forward.ToFMODVector();
-            attributes.up = transform.up.ToFMODVector();
-            attributes.position = transform.position.ToFMODVector();
+            attributes.forward = (rotation * Vector3.forward).ToFMODVector();
+            attributes.up = (rotation * Vector3.up).ToFMODVector();
+            attributes.position = position.ToFMODVector();
             attributes.velocity = velocity.ToFMODVector();
 
             return attributes;

--- a/Assets/Plugins/FMOD/src/StudioEventEmitter.cs
+++ b/Assets/Plugins/FMOD/src/StudioEventEmitter.cs
@@ -275,18 +275,16 @@ namespace FMODUnity
                 if (is3D)
                 {
 #if UNITY_PHYSICS_EXIST
-                    if (GetComponent<Rigidbody>())
+                    if (TryGetComponent(out Rigidbody rigidBody))
                     {
-                        Rigidbody rigidBody = GetComponent<Rigidbody>();
                         instance.set3DAttributes(RuntimeUtils.To3DAttributes(gameObject, rigidBody));
                         RuntimeManager.AttachInstanceToGameObject(instance, gameObject, rigidBody);
                     }
                     else
 #endif
 #if UNITY_PHYSICS2D_EXIST
-                    if (GetComponent<Rigidbody2D>())
+                    if (TryGetComponent(out Rigidbody2D rigidBody2D))
                     {
-                        var rigidBody2D = GetComponent<Rigidbody2D>();
                         instance.set3DAttributes(RuntimeUtils.To3DAttributes(gameObject, rigidBody2D));
                         RuntimeManager.AttachInstanceToGameObject(instance, gameObject, rigidBody2D);
                     }

--- a/Assets/Plugins/FMOD/src/StudioEventEmitter.cs
+++ b/Assets/Plugins/FMOD/src/StudioEventEmitter.cs
@@ -274,7 +274,6 @@ namespace FMODUnity
                 // Only want to update if we need to set 3D attributes
                 if (is3D)
                 {
-                    var transform = GetComponent<Transform>();
 #if UNITY_PHYSICS_EXIST
                     if (GetComponent<Rigidbody>())
                     {


### PR DESCRIPTION
Used Transform.GetPositionAndRotation in To3DAttributes to reduce the number of to engine calls.
Transform.forward/up already does a (rotation * Vector3.forward) so no new functionality is added.

Transform.GetPositionAndRotation is available since Unity 2021.3
https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Transform.GetPositionAndRotation.html

Replaced the two GetComponent calls in StudioEventEmitter.PlayInstance with TryGetComponent.

GameObject.TryGetComponent is available since Unity 2019.2
https://docs.unity3d.com/6000.3/Documentation/ScriptReference/GameObject.TryGetComponent.html